### PR TITLE
Make the mobile forecast accurate at its foundations and readable at a glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,35 @@ The data is available under MET Norway's
 - **Multi-Region Support**: Compare locations across different regions (e.g., Asturias, Spain, Worldwide) to plan trips effectively.
 - **Activity Profiles**: Rank the same forecast for either hiking/general outdoors or beach plans focused on swimming and sunbathing.
 - **Optimal Weather Finder**: Automatically identifies the best time blocks for the selected activity based on a weighted scoring system.
-- **Visual Scoring Analysis**: Color-coded side panel displaying the top locations sorted by weather quality.
+- **Local Time Everywhere**: Every forecast is interpreted in the time zone of the place it describes, so Tokyo's afternoon is Tokyo's afternoon.
 - **Windows and Android Interfaces**: Native-feeling Tkinter desktop and responsive Flet mobile layouts.
-- **Honest Missing-Data Display**: Missing precipitation is shown as `N/A`, not as a dry `0.0 mm` forecast.
+- **Honest Missing-Data Display**: A missing reading is shown as a dash and never forms the basis of a recommendation.
+
+## How the scores work
+
+Every score is on a 0-100 scale for the **selected activity**, where 100 is the
+best weather that activity can ask for. Two different scores appear, and each
+is labelled on screen because they answer different questions:
+
+| Score | What it measures | Where it appears |
+| --- | --- | --- |
+| **Window score** | How good the recommended hours are | Beside the recommended time window |
+| **Day score** | How good and how settled the whole usable day is | Beside each entry in the ranked list |
+
+The ranked list is ordered by the day score, which penalises weather that
+swings around, on the basis that a steady good day is a safer bet than one
+bright hour in an unsettled one. A location can therefore have an excellent
+window inside a poor day, and the screen says exactly that.
+
+Only hours that you can actually use are considered: daylight hours between
+08:00 and 20:00 local time, and for today, only those that have not passed.
+The ranking, the recommended window and the hourly breakdown inside each card
+all read from that same set of hours, so they cannot disagree.
+
+Beyond roughly two days, MET Norway publishes six-hourly rather than hourly
+data. Those entries are labelled as blocks, their rain totals are scored as a
+per-hour rate rather than as one hour's downpour, and windows are clamped to
+daylight so a block starting at 04:00 is never recommended as a 04:00 start.
 
 ## Installation and Usage
 

--- a/src/application/forecast_service.py
+++ b/src/application/forecast_service.py
@@ -10,7 +10,9 @@ from src.core.weather_api import fetch_weather_data
 
 ProcessedForecast = dict[str, Any]
 FetchForecast = Callable[[Location], Optional[dict[str, Any]]]
-ProcessForecast = Callable[[dict[str, Any], str], Optional[ProcessedForecast]]
+ProcessForecast = Callable[
+    [dict[str, Any], str, Optional[str]], Optional[ProcessedForecast]
+]
 ProgressCallback = Callable[[int, int, Location], None]
 
 logger = logging.getLogger(__name__)
@@ -66,7 +68,9 @@ class ForecastService:
                     error=DOWNLOAD_ERROR,
                 )
 
-            processed = self._process_forecast(raw_forecast, location.name)
+            processed = self._process_forecast(
+                raw_forecast, location.name, location.timezone
+            )
             if processed is None:
                 return LocationForecastResult(
                     location=location,

--- a/src/application/forecast_service.py
+++ b/src/application/forecast_service.py
@@ -1,6 +1,7 @@
 """UI-independent orchestration for fetching and processing forecasts."""
 
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping, Optional
 
@@ -16,6 +17,13 @@ ProcessForecast = Callable[
 ProgressCallback = Callable[[int, int, Location], None]
 
 logger = logging.getLogger(__name__)
+
+# MET Norway asks clients to stay modest; a handful of parallel requests keeps
+# a region loading quickly without hammering the service.
+MAX_CONCURRENT_REQUESTS = 6
+
+# How many failed locations to name before summarising the rest as a count.
+MAX_NAMED_FAILURES = 3
 
 DOWNLOAD_ERROR = "Could not download forecast data. Check your connection and try again."
 PROCESSING_ERROR = "The forecast response did not contain usable weather data."
@@ -41,10 +49,22 @@ class ForecastBatch:
 
     forecasts: dict[str, ProcessedForecast] = field(default_factory=dict)
     errors: dict[str, str] = field(default_factory=dict)
+    failed_names: dict[str, str] = field(default_factory=dict)
 
     @property
     def loaded_count(self) -> int:
         return len(self.forecasts)
+
+    @property
+    def failure_summary(self) -> str:
+        """Return a readable list of the locations that could not be loaded."""
+        names = sorted(self.failed_names.values())
+        if not names:
+            return ""
+        if len(names) <= MAX_NAMED_FAILURES:
+            return ", ".join(names)
+        listed = ", ".join(names[:MAX_NAMED_FAILURES])
+        return f"{listed} and {len(names) - MAX_NAMED_FAILURES} more"
 
 
 class ForecastService:
@@ -86,18 +106,42 @@ class ForecastService:
         locations: Mapping[str, Location],
         on_progress: Optional[ProgressCallback] = None,
     ) -> ForecastBatch:
-        """Load a location group, retaining successful partial results."""
+        """Load a location group concurrently, keeping partial results.
+
+        Locations were previously fetched one at a time, so a region of twenty
+        could take minutes on a phone before anything appeared. Requests now
+        overlap, and progress is reported as each one lands.
+        """
         forecasts: dict[str, ProcessedForecast] = {}
         errors: dict[str, str] = {}
+        failed_names: dict[str, str] = {}
         total = len(locations)
+        if not total:
+            return ForecastBatch()
 
-        for index, (location_key, location) in enumerate(locations.items(), start=1):
-            result = self.load_location(location)
-            if result.forecast is not None:
-                forecasts[location_key] = result.forecast
-            else:
-                errors[location_key] = result.error or "Unknown forecast error"
-            if on_progress:
-                on_progress(index, total, location)
+        with ThreadPoolExecutor(max_workers=self._worker_count(total)) as executor:
+            pending = {
+                executor.submit(self.load_location, location): location_key
+                for location_key, location in locations.items()
+            }
+            for completed, future in enumerate(as_completed(pending), start=1):
+                location_key = pending[future]
+                result = future.result()
+                if result.forecast is not None:
+                    forecasts[location_key] = result.forecast
+                else:
+                    errors[location_key] = result.error or "Unknown forecast error"
+                    failed_names[location_key] = result.location.name
+                if on_progress:
+                    on_progress(completed, total, result.location)
 
-        return ForecastBatch(forecasts=forecasts, errors=errors)
+        # Preserve the caller's ordering, which concurrency does not guarantee.
+        ordered = {key: forecasts[key] for key in locations if key in forecasts}
+        return ForecastBatch(
+            forecasts=ordered, errors=errors, failed_names=failed_names
+        )
+
+    @staticmethod
+    def _worker_count(total: int) -> int:
+        """Return a request concurrency that stays polite to the data source."""
+        return max(1, min(MAX_CONCURRENT_REQUESTS, total))

--- a/src/application/presentation.py
+++ b/src/application/presentation.py
@@ -19,12 +19,16 @@ BASE_COLORS = {
     "poor": "#b91c1c",
 }
 
+RATING_COLOR_KEYS = {
+    "Excellent": "excellent",
+    "Very Good": "very_good",
+    "Good": "good",
+    "Fair": "fair",
+    "Poor": "poor",
+}
+
 RATING_COLORS = {
-    "Excellent": BASE_COLORS["excellent"],
-    "Very Good": BASE_COLORS["very_good"],
-    "Good": BASE_COLORS["good"],
-    "Fair": BASE_COLORS["fair"],
-    "Poor": BASE_COLORS["poor"],
+    rating: BASE_COLORS[key] for rating, key in RATING_COLOR_KEYS.items()
 }
 
 RATING_BACKGROUNDS = {
@@ -35,15 +39,73 @@ RATING_BACKGROUNDS = {
     "Poor": "#fef2f2",
 }
 
+# Dark-mode equivalents. Rating hues stay recognisable but are lightened so
+# they keep their contrast against a dark surface.
+DARK_COLORS = {
+    "primary": "#93b4ff",
+    "background": "#0f172a",
+    "surface": "#1e293b",
+    "border": "#334155",
+    "text": "#e2e8f0",
+    "text_secondary": "#94a3b8",
+    "excellent": "#4ade80",
+    "very_good": "#a3e635",
+    "good": "#facc15",
+    "fair": "#fb923c",
+    "poor": "#f87171",
+}
 
-def get_rating_color(rating: str) -> str:
+DARK_RATING_BACKGROUNDS = {
+    "Excellent": "#16321f",
+    "Very Good": "#26310f",
+    "Good": "#332b0b",
+    "Fair": "#3a2410",
+    "Poor": "#3b1616",
+}
+
+RATING_ORDER = ("Excellent", "Very Good", "Good", "Fair", "Poor")
+
+
+def get_palette(dark: bool = False) -> dict:
+    """Return the colour palette for the requested brightness."""
+    return DARK_COLORS if dark else BASE_COLORS
+
+
+def get_rating_color(rating: str, dark: bool = False) -> str:
     """Return the shared foreground color for a descriptive rating."""
-    return RATING_COLORS.get(rating, BASE_COLORS["text"])
+    palette = get_palette(dark)
+    key = RATING_COLOR_KEYS.get(rating)
+    if key is None:
+        return palette["text"]
+    return palette[key]
 
 
-def get_rating_background(rating: str) -> str:
+def get_rating_background(rating: str, dark: bool = False) -> str:
     """Return the subtle background color for a descriptive rating."""
-    return RATING_BACKGROUNDS.get(rating, BASE_COLORS["surface"])
+    backgrounds = DARK_RATING_BACKGROUNDS if dark else RATING_BACKGROUNDS
+    return backgrounds.get(rating, get_palette(dark)["surface"])
+
+
+MISSING_VALUE = "—"
+
+
+def format_optional(value: Optional[NumericType], formatter) -> str:
+    """Format a value, or return the shared missing-data marker.
+
+    Missing readings are shown as a dash rather than a plausible-looking
+    number, so a gap in the source data can never be mistaken for weather.
+    """
+    return MISSING_VALUE if value is None else formatter(value)
+
+
+def format_relative_date(value: date, today: date) -> str:
+    """Label a date relative to today when that is what a person would say."""
+    delta = (value - today).days
+    if delta == 0:
+        return "Today"
+    if delta == 1:
+        return "Tomorrow"
+    return value.strftime("%a, %d %b")
 
 
 def format_time(value: datetime) -> str:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -2,11 +2,14 @@
 Configuration constants and type definitions for the Weather Helper application.
 """
 
+import logging
 from datetime import date, datetime
 from functools import lru_cache
-from typing import Union
+from typing import Optional, Union
 
 import pytz
+
+logger = logging.getLogger(__name__)
 
 # Type definitions
 NumericType = Union[int, float]
@@ -20,7 +23,7 @@ API_URL = "https://api.met.no/weatherapi/locationforecast/2.0/complete"
 API_URL_COMPACT = "https://api.met.no/weatherapi/locationforecast/2.0/compact"
 
 
-# Time zone
+# Fallback time zone for locations that do not declare their own.
 TIMEZONE = "Europe/Madrid"
 
 # Weather display settings
@@ -31,19 +34,32 @@ DAYLIGHT_START_HOUR = 8
 
 # Utility functions
 @lru_cache(maxsize=None)
-def get_timezone():
-    """Get the application timezone object."""
-    return pytz.timezone(TIMEZONE)
+def get_timezone(timezone_name: Optional[str] = None):
+    """Get a timezone object, falling back to the application default.
+
+    Every forecast is interpreted in the time zone of the place it describes,
+    so callers pass the location's own zone. An unknown zone name falls back to
+    the application default rather than failing a whole forecast load.
+    """
+    if not timezone_name:
+        return pytz.timezone(TIMEZONE)
+    try:
+        return pytz.timezone(timezone_name)
+    except pytz.UnknownTimeZoneError:
+        logger.warning(
+            "Unknown time zone %r; falling back to %s", timezone_name, TIMEZONE
+        )
+        return pytz.timezone(TIMEZONE)
 
 
-def get_current_datetime() -> datetime:
-    """Get the current datetime in the application timezone."""
-    return datetime.now(get_timezone())
+def get_current_datetime(timezone_name: Optional[str] = None) -> datetime:
+    """Get the current datetime in a location's time zone."""
+    return datetime.now(get_timezone(timezone_name))
 
 
-def get_current_date() -> date:
-    """Get the current date in the application timezone."""
-    return get_current_datetime().date()
+def get_current_date(timezone_name: Optional[str] = None) -> date:
+    """Get the current date in a location's time zone."""
+    return get_current_datetime(timezone_name).date()
 
 
 def safe_average(values: list[NumericType]) -> float | None:

--- a/src/core/evaluation.py
+++ b/src/core/evaluation.py
@@ -28,8 +28,9 @@ from src.core.scoring import (
     wind_score,
 )
 
-ADJACENT_FORECAST_MINUTES_MIN = 50
-ADJACENT_FORECAST_MINUTES_MAX = 70
+HOURLY_COVERAGE_HOURS = 1
+SIX_HOURLY_COVERAGE_HOURS = 6
+ADJACENT_TOLERANCE_MINUTES = 10
 CURRENT_HOUR_RELEVANCE_MINUTE = 30
 DEFAULT_MAX_SCORE_VARIANCE = 7.0
 OPTIMAL_MAX_SCORE_VARIANCE = 8.0
@@ -85,19 +86,16 @@ def _are_adjacent_forecast_hours(
     previous_hour: HourlyWeather,
     next_hour: HourlyWeather,
 ) -> bool:
-    """Return True when two forecast entries represent adjacent hourly data."""
-    delta = next_hour.time - previous_hour.time
-    return _adjacent_min_delta() <= delta <= _adjacent_max_delta()
+    """Return True when one forecast entry continues directly into the next.
 
-
-def _adjacent_min_delta() -> timedelta:
-    """Return the shortest allowed gap between adjacent forecast rows."""
-    return timedelta(minutes=ADJACENT_FORECAST_MINUTES_MIN)
-
-
-def _adjacent_max_delta() -> timedelta:
-    """Return the longest allowed gap between adjacent forecast rows."""
-    return timedelta(minutes=ADJACENT_FORECAST_MINUTES_MAX)
+    Entries are adjacent when the next one starts where the previous one stops,
+    which keeps hourly and six-hourly data on the same footing and refuses to
+    bridge a gap between two different resolutions.
+    """
+    if previous_hour.coverage_hours != next_hour.coverage_hours:
+        return False
+    gap = abs(next_hour.time - previous_hour.end_time)
+    return gap <= timedelta(minutes=ADJACENT_TOLERANCE_MINUTES)
 
 
 def _get_period_data(
@@ -109,17 +107,28 @@ def _get_period_data(
 
 
 def _is_daylight_hour(hour: HourlyWeather) -> bool:
-    """Return True when an hour is inside the configured daytime window."""
-    return DAYLIGHT_START_HOUR <= hour.hour <= DAYLIGHT_END_HOUR
+    """Return True when an entry overlaps the configured daytime window.
+
+    Six-hourly entries are kept when any part of them falls inside the window,
+    so a 06:00-12:00 entry still counts towards a morning recommendation.
+    """
+    starts_before_window_ends = hour.hour <= DAYLIGHT_END_HOUR
+    ends_after_window_starts = (
+        hour.hour + hour.coverage_hours > DAYLIGHT_START_HOUR
+    )
+    return starts_before_window_ends and ends_after_window_starts
 
 
 def _is_future_or_current_hour(hour: HourlyWeather, now_local: datetime) -> bool:
-    """Return True when an hour is still useful for today's recommendations."""
-    return (
-        hour.time > now_local
-        or hour.time.hour == now_local.hour
-        and now_local.minute < CURRENT_HOUR_RELEVANCE_MINUTE
-    )
+    """Return True when an entry still has usable time left in it.
+
+    An entry counts while it is running, but only if enough of it remains to be
+    worth recommending, so a window is never suggested as it is ending.
+    """
+    if hour.time > now_local:
+        return True
+    remaining = hour.end_time - now_local
+    return remaining >= timedelta(minutes=CURRENT_HOUR_RELEVANCE_MINUTE)
 
 
 def _filter_hours_for_recommendations(
@@ -176,6 +185,7 @@ def _extract_hourly_weather_values(
     precipitation_amount, precipitation_probability = _get_precipitation_values(entry)
 
     return {
+        "coverage_hours": _get_coverage_hours(entry),
         "time": _parse_local_forecast_time(entry["time"], timezone_name),
         "temp": instant_details.get("air_temperature"),
         "wind": instant_details.get("wind_speed"),
@@ -195,6 +205,22 @@ def _parse_local_forecast_time(
     """Parse an API timestamp into a location's local time."""
     time_utc = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
     return time_utc.astimezone(get_timezone(timezone_name))
+
+
+def _get_coverage_hours(entry: dict[str, Any]) -> int:
+    """Return how many hours a timeseries entry describes.
+
+    MET Norway publishes hourly entries for roughly the first two days and
+    six-hourly entries after that. Treating a six-hour entry as a single hour
+    would misreport both rain totals and the length of a recommended window.
+    """
+    next_1h_summary, next_1h_details = _get_period_data(entry, "next_1_hours")
+    if next_1h_summary or next_1h_details:
+        return HOURLY_COVERAGE_HOURS
+    next_6h_summary, next_6h_details = _get_period_data(entry, "next_6_hours")
+    if next_6h_summary or next_6h_details:
+        return SIX_HOURLY_COVERAGE_HOURS
+    return HOURLY_COVERAGE_HOURS
 
 
 def _get_precipitation_values(
@@ -233,9 +259,17 @@ def _build_hourly_weather(values: dict[str, Any]) -> HourlyWeather:
         temp_score=temp_score(values["temp"]),
         wind_score=wind_score(values["wind"]),
         cloud_score=cloud_score(values["cloud_coverage"]),
-        precip_amount_score=precip_amount_score(values["precipitation_amount"]),
+        precip_amount_score=precip_amount_score(_precipitation_rate(values)),
         humidity_score=humidity_score(values["relative_humidity"]),
     )
+
+
+def _precipitation_rate(values: dict[str, Any]) -> Optional[NumericType]:
+    """Return precipitation in mm per hour for an extracted entry."""
+    amount = values["precipitation_amount"]
+    if amount is None:
+        return None
+    return amount / max(1, values.get("coverage_hours", HOURLY_COVERAGE_HOURS))
 
 
 def _process_timeseries(
@@ -460,8 +494,11 @@ def _base_block_info(
         "block": block,
         "start": block[0].time,
         "end": block[-1].time,
+        "end_time": block[-1].end_time,
         "avg_score": avg_score,
         "duration": len(block),
+        "duration_hours": sum(hour.coverage_hours for hour in block),
+        "coverage_hours": block[0].coverage_hours,
         "consistency": 1 / (1 + std_dev),
         "variance": std_dev,
     }
@@ -548,10 +585,11 @@ def _duration_bonus(positive_hour_count: int) -> float:
 def _positive_hour_count(
     block_info: dict[str, Any], activity_profile: str
 ) -> int:
-    """Return the number of individually positive hours in a block."""
+    """Return how many hours inside a block score positively."""
     return sum(
-        get_activity_score(hour, activity_profile) > 0
+        hour.coverage_hours
         for hour in block_info["block"]
+        if get_activity_score(hour, activity_profile) > 0
     )
 
 

--- a/src/core/evaluation.py
+++ b/src/core/evaluation.py
@@ -120,21 +120,8 @@ def _is_daylight_hour(hour: HourlyWeather) -> bool:
 
 
 def daylight_bounds(hour: HourlyWeather) -> tuple[datetime, datetime]:
-    """Return the part of an entry that falls inside the daylight window.
-
-    A six-hour entry starting at 04:00 counts towards the morning, but telling
-    someone their best window begins at 04:00 would be nonsense. Only the
-    daylight part of an entry is ever presented as time to go out.
-    """
-    day_start = hour.time.replace(
-        hour=DAYLIGHT_START_HOUR, minute=0, second=0, microsecond=0
-    )
-    day_end = hour.time.replace(
-        hour=DAYLIGHT_END_HOUR, minute=0, second=0, microsecond=0
-    ) + timedelta(hours=1)
-    start = max(hour.time, day_start)
-    end = min(hour.end_time, day_end)
-    return start, max(start, end)
+    """Return the part of an entry that falls inside the daylight window."""
+    return hour.daylight_span
 
 
 def _is_future_or_current_hour(hour: HourlyWeather, now_local: datetime) -> bool:
@@ -528,11 +515,7 @@ def _base_block_info(
 
 def _daylight_hours_in(block: list[HourlyWeather]) -> int:
     """Return how many usable daylight hours a block really offers."""
-    total = timedelta()
-    for hour in block:
-        start, end = daylight_bounds(hour)
-        total += end - start
-    return int(round(total.total_seconds() / 3600))
+    return sum(hour.daylight_hours for hour in block)
 
 
 def _weather_block_info(block: list[HourlyWeather]) -> dict[str, Optional[float]]:
@@ -616,9 +599,14 @@ def _duration_bonus(positive_hour_count: int) -> float:
 def _positive_hour_count(
     block_info: dict[str, Any], activity_profile: str
 ) -> int:
-    """Return how many hours inside a block score positively."""
+    """Return how many usable daylight hours inside a block score positively.
+
+    Counting an entry's whole span would hand a six-hour block that only
+    overlaps daylight by an hour the same duration bonus as a genuine
+    six-hour stretch of good weather.
+    """
     return sum(
-        hour.coverage_hours
+        hour.daylight_hours
         for hour in block_info["block"]
         if get_activity_score(hour, activity_profile) > 0
     )

--- a/src/core/evaluation.py
+++ b/src/core/evaluation.py
@@ -633,14 +633,19 @@ def _rank_location_for_date(
     activity_profile: str,
 ) -> Optional[dict[str, Any]]:
     """Return a ranked location result for a date, if data is usable."""
-    report = processed.get("day_scores", {}).get(forecast_date)
-    if not report:
+    if not processed.get("day_scores", {}).get(forecast_date):
         return None
-    filtered_hours = _location_recommendation_hours(processed, forecast_date, now_local)
+    filtered_hours = get_recommendation_hours(processed, forecast_date, now_local)
+    if not filtered_hours:
+        return None
     optimal_block = _find_optimal_consistent_block(filtered_hours, activity_profile)
     if not optimal_block:
         return None
-    day_score = _calculate_day_activity_score(report.daylight_hours, activity_profile)
+
+    # Score the day on the same hours the window was drawn from, so a location
+    # is never ranked highly on a morning that has already passed.
+    report = _daily_report(forecast_date, filtered_hours, _location_name(processed))
+    day_score = _calculate_day_activity_score(filtered_hours, activity_profile)
     return _build_location_result(
         loc_key,
         report,
@@ -650,15 +655,30 @@ def _rank_location_for_date(
     )
 
 
-def _location_recommendation_hours(
-    processed: dict, forecast_date: date, now_local: datetime
+def _location_name(processed: dict) -> str:
+    """Return the location name recorded on a processed forecast."""
+    for report in processed.get("day_scores", {}).values():
+        return report.location_name
+    return ""
+
+
+def get_recommendation_hours(
+    processed: dict,
+    forecast_date: date,
+    now_local: Optional[datetime] = None,
 ) -> list[HourlyWeather]:
-    """Return forecast hours considered for a location recommendation."""
+    """Return the forecast entries a recommendation for a date is based on.
+
+    This is the single definition of "hours that count": daylight entries, and
+    for today only those with usable time left. The ranking, the recommended
+    window and the hourly breakdown shown to the user all read from here, so
+    they can never disagree about which hours were considered.
+    """
     daily_forecasts = processed.get("daily_forecasts", {})
     return _filter_hours_for_recommendations(
-        daily_forecasts.get(forecast_date, []),
+        sorted(daily_forecasts.get(forecast_date, []), key=lambda hour: hour.time),
         forecast_date,
-        now_local,
+        now_local if now_local is not None else _location_now(processed),
     )
 
 

--- a/src/core/evaluation.py
+++ b/src/core/evaluation.py
@@ -470,7 +470,9 @@ def _is_acceptable_block(
     std_dev: float,
     max_score_variance: float,
 ) -> bool:
-    """Return True when a block passes score and variance thresholds."""
+    """Return True when a block passes score, data and variance thresholds."""
+    if not all(hour.has_core_readings for hour in block):
+        return False
     if avg_score < _minimum_average_score(len(block)):
         return False
     return std_dev <= _adjusted_variance_threshold(len(block), max_score_variance)
@@ -643,7 +645,10 @@ def get_top_locations_for_date(
         )
         if location_result:
             results.append(location_result)
-    results.sort(key=lambda x: x["score"], reverse=True)
+    # Locations are ranked on the day as a whole, including a penalty for
+    # volatile weather: a steady good day is a safer bet than one bright hour
+    # in an unsettled one. The window's own score is reported separately.
+    results.sort(key=lambda x: (x["score"], x["window_score"]), reverse=True)
     return results[:top_n]
 
 
@@ -718,15 +723,22 @@ def _build_location_result(
     day_score: dict[str, float],
     activity_profile: str,
 ) -> dict[str, Any]:
-    """Build the side-panel result dictionary for a location."""
+    """Build the ranking result for one location on one date.
+
+    Two different scores matter and they are kept distinct: the day score,
+    which ranks locations and accounts for how settled the weather is, and the
+    window score, which describes the specific hours being recommended. The
+    interface labels both, because a single unlabelled number printed beside a
+    time reads as a claim about that time.
+    """
     return {
         "location_key": loc_key,
         "location_name": report.location_name,
         "score": day_score["score"],
         "raw_score": day_score["score"],
+        "window_score": optimal_block["avg_score"],
         "day_avg_score": day_score["average"],
         "volatility_penalty": day_score["volatility_penalty"],
-        "window_score": optimal_block["avg_score"],
         "optimal_block": optimal_block,
         "weather_desc": report.weather_description,
         "activity_profile": activity_profile,

--- a/src/core/evaluation.py
+++ b/src/core/evaluation.py
@@ -160,19 +160,23 @@ def _valid_minimum_duration_block(
     return block
 
 
-def _create_hourly_weather(entry: dict[str, Any]) -> HourlyWeather:
+def _create_hourly_weather(
+    entry: dict[str, Any], timezone_name: Optional[str] = None
+) -> HourlyWeather:
     """Create an HourlyWeather object from a forecast timeseries entry."""
-    weather_values = _extract_hourly_weather_values(entry)
+    weather_values = _extract_hourly_weather_values(entry, timezone_name)
     return _build_hourly_weather(weather_values)
 
 
-def _extract_hourly_weather_values(entry: dict[str, Any]) -> dict[str, Any]:
+def _extract_hourly_weather_values(
+    entry: dict[str, Any], timezone_name: Optional[str] = None
+) -> dict[str, Any]:
     """Extract raw weather values from a timeseries entry."""
     instant_details = entry["data"]["instant"]["details"]
     precipitation_amount, precipitation_probability = _get_precipitation_values(entry)
-    
+
     return {
-        "time": _parse_local_forecast_time(entry["time"]),
+        "time": _parse_local_forecast_time(entry["time"], timezone_name),
         "temp": instant_details.get("air_temperature"),
         "wind": instant_details.get("wind_speed"),
         "cloud_coverage": instant_details.get("cloud_area_fraction"),
@@ -185,10 +189,12 @@ def _extract_hourly_weather_values(entry: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _parse_local_forecast_time(timestamp: str) -> datetime:
-    """Parse an API timestamp into the application timezone."""
+def _parse_local_forecast_time(
+    timestamp: str, timezone_name: Optional[str] = None
+) -> datetime:
+    """Parse an API timestamp into a location's local time."""
     time_utc = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-    return time_utc.astimezone(get_timezone())
+    return time_utc.astimezone(get_timezone(timezone_name))
 
 
 def _get_precipitation_values(
@@ -233,15 +239,16 @@ def _build_hourly_weather(values: dict[str, Any]) -> HourlyWeather:
 
 
 def _process_timeseries(
-    forecast_timeseries: list[dict[str, Any]]
+    forecast_timeseries: list[dict[str, Any]],
+    timezone_name: Optional[str] = None,
 ) -> dict[date, list[HourlyWeather]]:
-    """Group a raw forecast timeseries by date."""
+    """Group a raw forecast timeseries by the location's local date."""
     daily_forecasts: dict[date, list[HourlyWeather]] = defaultdict(list)
-    today = get_current_date()
+    today = get_current_date(timezone_name)
     end_date = today + timedelta(days=FORECAST_DAYS)
 
     for entry in forecast_timeseries:
-        _append_forecast_entry(entry, daily_forecasts, today, end_date)
+        _append_forecast_entry(entry, daily_forecasts, today, end_date, timezone_name)
 
     return dict(daily_forecasts)
 
@@ -251,26 +258,42 @@ def _append_forecast_entry(
     daily_forecasts: dict[date, list[HourlyWeather]],
     today: date,
     end_date: date,
+    timezone_name: Optional[str] = None,
 ) -> None:
     """Append a timeseries entry to the corresponding daily forecast list."""
-    forecast_time = _parse_local_forecast_time(entry["time"])
+    forecast_time = _parse_local_forecast_time(entry["time"], timezone_name)
     forecast_date = forecast_time.date()
 
     if today <= forecast_date <= end_date:
-        daily_forecasts[forecast_date].append(_create_hourly_weather(entry))
+        daily_forecasts[forecast_date].append(
+            _create_hourly_weather(entry, timezone_name)
+        )
 
 
-def process_forecast(forecast_data: dict, location_name: str) -> Optional[dict]:
-    """Process weather forecast data into daily summaries and hourly blocks."""
+def process_forecast(
+    forecast_data: dict,
+    location_name: str,
+    timezone_name: Optional[str] = None,
+) -> Optional[dict]:
+    """Process weather forecast data into daily summaries and hourly blocks.
+
+    All times are converted to the location's own time zone, so the daylight
+    window and "already passed" checks describe the place being forecast rather
+    than wherever the app happens to be configured.
+    """
     weather_data = forecast_data.get("weather", forecast_data)
-    
+
     forecast_timeseries = _get_forecast_timeseries(weather_data)
     if forecast_timeseries is None:
         return None
-        
-    daily_forecasts = _process_timeseries(forecast_timeseries)
+
+    daily_forecasts = _process_timeseries(forecast_timeseries, timezone_name)
     day_scores_reports = _build_daily_reports(daily_forecasts, location_name)
-    return {"daily_forecasts": daily_forecasts, "day_scores": day_scores_reports}
+    return {
+        "daily_forecasts": daily_forecasts,
+        "day_scores": day_scores_reports,
+        "timezone": timezone_name,
+    }
 
 
 def _get_forecast_timeseries(forecast_data: dict) -> Optional[list[dict[str, Any]]]:
@@ -547,15 +570,21 @@ def get_top_locations_for_date(
 ) -> list[dict]:
     """Return the top N locations for a given date."""
     results = []
-    now_local = datetime.now(timezone.utc).astimezone(get_timezone())
     for loc_key, processed in all_location_processed.items():
         location_result = _rank_location_for_date(
-            loc_key, processed, d, now_local, activity_profile
+            loc_key, processed, d, _location_now(processed), activity_profile
         )
         if location_result:
             results.append(location_result)
     results.sort(key=lambda x: x["score"], reverse=True)
     return results[:top_n]
+
+
+def _location_now(processed: dict) -> datetime:
+    """Return the current time in the time zone of a processed forecast."""
+    return datetime.now(timezone.utc).astimezone(
+        get_timezone(processed.get("timezone"))
+    )
 
 
 def _rank_location_for_date(

--- a/src/core/evaluation.py
+++ b/src/core/evaluation.py
@@ -119,6 +119,24 @@ def _is_daylight_hour(hour: HourlyWeather) -> bool:
     return starts_before_window_ends and ends_after_window_starts
 
 
+def daylight_bounds(hour: HourlyWeather) -> tuple[datetime, datetime]:
+    """Return the part of an entry that falls inside the daylight window.
+
+    A six-hour entry starting at 04:00 counts towards the morning, but telling
+    someone their best window begins at 04:00 would be nonsense. Only the
+    daylight part of an entry is ever presented as time to go out.
+    """
+    day_start = hour.time.replace(
+        hour=DAYLIGHT_START_HOUR, minute=0, second=0, microsecond=0
+    )
+    day_end = hour.time.replace(
+        hour=DAYLIGHT_END_HOUR, minute=0, second=0, microsecond=0
+    ) + timedelta(hours=1)
+    start = max(hour.time, day_start)
+    end = min(hour.end_time, day_end)
+    return start, max(start, end)
+
+
 def _is_future_or_current_hour(hour: HourlyWeather, now_local: datetime) -> bool:
     """Return True when an entry still has usable time left in it.
 
@@ -490,18 +508,29 @@ def _base_block_info(
     block: list[HourlyWeather], avg_score: float, std_dev: float
 ) -> dict[str, Any]:
     """Return timing, score, and consistency fields for a block."""
+    window_start, _ = daylight_bounds(block[0])
+    _, window_end = daylight_bounds(block[-1])
     return {
         "block": block,
-        "start": block[0].time,
+        "start": window_start,
         "end": block[-1].time,
-        "end_time": block[-1].end_time,
+        "end_time": window_end,
         "avg_score": avg_score,
         "duration": len(block),
-        "duration_hours": sum(hour.coverage_hours for hour in block),
+        "duration_hours": _daylight_hours_in(block),
         "coverage_hours": block[0].coverage_hours,
         "consistency": 1 / (1 + std_dev),
         "variance": std_dev,
     }
+
+
+def _daylight_hours_in(block: list[HourlyWeather]) -> int:
+    """Return how many usable daylight hours a block really offers."""
+    total = timedelta()
+    for hour in block:
+        start, end = daylight_bounds(hour)
+        total += end - start
+    return int(round(total.total_seconds() / 3600))
 
 
 def _weather_block_info(block: list[HourlyWeather]) -> dict[str, Optional[float]]:

--- a/src/core/locations.py
+++ b/src/core/locations.py
@@ -4,6 +4,11 @@ Defines the Location class and the dictionary of known locations.
 
 from typing import Dict, NamedTuple
 
+from src.core.config import TIMEZONE
+
+SPAIN_MAINLAND_TZ = "Europe/Madrid"
+CANARY_ISLANDS_TZ = "Atlantic/Canary"
+
 
 class Location(NamedTuple):
     """Represents a geographical location with coordinates.
@@ -13,67 +18,69 @@ class Location(NamedTuple):
         name: Human-readable name of the location
         lat: Latitude coordinate
         lon: Longitude coordinate
+        timezone: IANA time zone name used to interpret this location's forecast
     """
 
     key: str
     name: str
     lat: float
     lon: float
+    timezone: str = TIMEZONE
 
 
 # Northern Spain / Asturias
 ASTURIAS_LOCATIONS: Dict[str, Location] = {
-    "gijon": Location("gijon", "Gijón", 43.5322, -5.6610),
-    "oviedo": Location("oviedo", "Oviedo", 43.3623, -5.8485),
-    "llanes": Location("llanes", "Llanes", 43.4211, -4.7562),
-    "aviles": Location("aviles", "Avilés", 43.5567, -5.9256),
-    "luarca": Location("luarca", "Luarca", 43.5420, -6.5359),
-    "luanco": Location("luanco", "Luanco", 43.6137, -5.7929),
-    "salinas": Location("salinas", "Salinas", 43.5753, -5.9585),
-    "cudillero": Location("cudillero", "Cudillero", 43.5629, -6.1453),
-    "ribadesella": Location("ribadesella", "Ribadesella", 43.4631, -5.0567),
-    "cangas_de_onis": Location("cangas_de_onis", "Cangas de Onís", 43.3514, -5.1292),
-    "villaviciosa": Location("villaviciosa", "Villaviciosa", 43.4814, -5.4356),
-    "lastres": Location("lastres", "Lastres", 43.5135, -5.2696),
+    "gijon": Location("gijon", "Gijón", 43.5322, -5.6610, SPAIN_MAINLAND_TZ),
+    "oviedo": Location("oviedo", "Oviedo", 43.3623, -5.8485, SPAIN_MAINLAND_TZ),
+    "llanes": Location("llanes", "Llanes", 43.4211, -4.7562, SPAIN_MAINLAND_TZ),
+    "aviles": Location("aviles", "Avilés", 43.5567, -5.9256, SPAIN_MAINLAND_TZ),
+    "luarca": Location("luarca", "Luarca", 43.5420, -6.5359, SPAIN_MAINLAND_TZ),
+    "luanco": Location("luanco", "Luanco", 43.6137, -5.7929, SPAIN_MAINLAND_TZ),
+    "salinas": Location("salinas", "Salinas", 43.5753, -5.9585, SPAIN_MAINLAND_TZ),
+    "cudillero": Location("cudillero", "Cudillero", 43.5629, -6.1453, SPAIN_MAINLAND_TZ),
+    "ribadesella": Location("ribadesella", "Ribadesella", 43.4631, -5.0567, SPAIN_MAINLAND_TZ),
+    "cangas_de_onis": Location("cangas_de_onis", "Cangas de Onís", 43.3514, -5.1292, SPAIN_MAINLAND_TZ),
+    "villaviciosa": Location("villaviciosa", "Villaviciosa", 43.4814, -5.4356, SPAIN_MAINLAND_TZ),
+    "lastres": Location("lastres", "Lastres", 43.5135, -5.2696, SPAIN_MAINLAND_TZ),
 }
 
 # Rest of Spain
 SPAIN_OTHER_LOCATIONS: Dict[str, Location] = {
-    "alicante": Location("alicante", "Alicante", 38.3452, -0.4830),
-    "madrid": Location("madrid", "Madrid", 40.4165, -3.7026),
-    "barcelona": Location("barcelona", "Barcelona", 41.3888, 2.1590),
-    "valencia": Location("valencia", "València", 39.4699, -0.3763),
-    "sevilla": Location("sevilla", "Sevilla", 37.3891, -5.9845),
-    "granada": Location("granada", "Granada", 37.1882, -3.6067),
-    "malaga": Location("malaga", "Málaga", 36.7213, -4.4214),
-    "cordoba": Location("cordoba", "Córdoba", 37.8882, -4.7794),
-    "zaragoza": Location("zaragoza", "Zaragoza", 41.6488, -0.8891),
-    "murcia": Location("murcia", "Murcia", 37.9922, -1.1307),
-    "valladolid": Location("valladolid", "Valladolid", 41.6523, -4.7245),
-    "bilbao": Location("bilbao", "Bilbao", 43.2630, -2.9350),
-    "palma": Location("palma", "Palma", 39.5696, 2.6502),
-    "tenerife": Location("tenerife", "Tenerife (Santa Cruz)", 28.4636, -16.2518),
-    "las_palmas": Location("las_palmas", "Las Palmas de Gran Canaria", 28.1235, -15.4363),
-    "almeria": Location("almeria", "Almería", 36.8300, -2.4300),
-    "salobrena": Location("salobrena", "Salobreña", 36.7432, -3.5866),
-    "almunecar": Location("almunecar", "Almuñécar", 36.7339, -3.6907),
-    "motril": Location("motril", "Motril", 36.7460, -3.5204),
+    "alicante": Location("alicante", "Alicante", 38.3452, -0.4830, SPAIN_MAINLAND_TZ),
+    "madrid": Location("madrid", "Madrid", 40.4165, -3.7026, SPAIN_MAINLAND_TZ),
+    "barcelona": Location("barcelona", "Barcelona", 41.3888, 2.1590, SPAIN_MAINLAND_TZ),
+    "valencia": Location("valencia", "València", 39.4699, -0.3763, SPAIN_MAINLAND_TZ),
+    "sevilla": Location("sevilla", "Sevilla", 37.3891, -5.9845, SPAIN_MAINLAND_TZ),
+    "granada": Location("granada", "Granada", 37.1882, -3.6067, SPAIN_MAINLAND_TZ),
+    "malaga": Location("malaga", "Málaga", 36.7213, -4.4214, SPAIN_MAINLAND_TZ),
+    "cordoba": Location("cordoba", "Córdoba", 37.8882, -4.7794, SPAIN_MAINLAND_TZ),
+    "zaragoza": Location("zaragoza", "Zaragoza", 41.6488, -0.8891, SPAIN_MAINLAND_TZ),
+    "murcia": Location("murcia", "Murcia", 37.9922, -1.1307, SPAIN_MAINLAND_TZ),
+    "valladolid": Location("valladolid", "Valladolid", 41.6523, -4.7245, SPAIN_MAINLAND_TZ),
+    "bilbao": Location("bilbao", "Bilbao", 43.2630, -2.9350, SPAIN_MAINLAND_TZ),
+    "palma": Location("palma", "Palma", 39.5696, 2.6502, SPAIN_MAINLAND_TZ),
+    "tenerife": Location("tenerife", "Tenerife (Santa Cruz)", 28.4636, -16.2518, CANARY_ISLANDS_TZ),
+    "las_palmas": Location("las_palmas", "Las Palmas de Gran Canaria", 28.1235, -15.4363, CANARY_ISLANDS_TZ),
+    "almeria": Location("almeria", "Almería", 36.8300, -2.4300, SPAIN_MAINLAND_TZ),
+    "salobrena": Location("salobrena", "Salobreña", 36.7432, -3.5866, SPAIN_MAINLAND_TZ),
+    "almunecar": Location("almunecar", "Almuñécar", 36.7339, -3.6907, SPAIN_MAINLAND_TZ),
+    "motril": Location("motril", "Motril", 36.7460, -3.5204, SPAIN_MAINLAND_TZ),
 }
 
 # Worldwide
 WORLDWIDE_OTHER_LOCATIONS: Dict[str, Location] = {
-    "london": Location("london", "London", 51.5074, -0.1278),
-    "paris": Location("paris", "Paris", 48.8566, 2.3522),
-    "new_york": Location("new_york", "New York", 40.7128, -74.0060),
-    "tokyo": Location("tokyo", "Tokyo", 35.6762, 139.6503),
-    "berlin": Location("berlin", "Berlin", 52.5200, 13.4050),
-    "rome": Location("rome", "Rome", 41.9028, 12.4964),
-    "amsterdam": Location("amsterdam", "Amsterdam", 52.3676, 4.9041),
-    "prague": Location("prague", "Prague", 50.0880, 14.4208),
-    "lisbon": Location("lisbon", "Lisbon", 38.7223, -9.1393),
-    "houston": Location("houston", "Houston", 29.7604, -95.3698),
-    "rio_de_janeiro": Location("rio_de_janeiro", "Rio de Janeiro", -22.9068, -43.1729),
-    "buenos_aires": Location("buenos_aires", "Buenos Aires", -34.6037, -58.3816),
+    "london": Location("london", "London", 51.5074, -0.1278, "Europe/London"),
+    "paris": Location("paris", "Paris", 48.8566, 2.3522, "Europe/Paris"),
+    "new_york": Location("new_york", "New York", 40.7128, -74.0060, "America/New_York"),
+    "tokyo": Location("tokyo", "Tokyo", 35.6762, 139.6503, "Asia/Tokyo"),
+    "berlin": Location("berlin", "Berlin", 52.5200, 13.4050, "Europe/Berlin"),
+    "rome": Location("rome", "Rome", 41.9028, 12.4964, "Europe/Rome"),
+    "amsterdam": Location("amsterdam", "Amsterdam", 52.3676, 4.9041, "Europe/Amsterdam"),
+    "prague": Location("prague", "Prague", 50.0880, 14.4208, "Europe/Prague"),
+    "lisbon": Location("lisbon", "Lisbon", 38.7223, -9.1393, "Europe/Lisbon"),
+    "houston": Location("houston", "Houston", 29.7604, -95.3698, "America/Chicago"),
+    "rio_de_janeiro": Location("rio_de_janeiro", "Rio de Janeiro", -22.9068, -43.1729, "America/Sao_Paulo"),
+    "buenos_aires": Location("buenos_aires", "Buenos Aires", -34.6037, -58.3816, "America/Argentina/Buenos_Aires"),
 }
 
 # Combined lists

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Optional
 
-from src.core.config import NumericType, safe_average
+from src.core.config import (
+    DAYLIGHT_END_HOUR,
+    DAYLIGHT_START_HOUR,
+    NumericType,
+    safe_average,
+)
 
 SIGNIFICANT_RAIN_MM = 0.5
 WARM_TEMP_C = 22
@@ -54,6 +59,30 @@ class HourlyWeather:
     def is_hourly(self) -> bool:
         """Return True when this entry describes a single hour."""
         return self.coverage_hours == 1
+
+    @property
+    def daylight_span(self) -> tuple[datetime, datetime]:
+        """Return the part of this entry that falls inside the daylight window.
+
+        A six-hour entry starting at 04:00 counts towards the morning, but only
+        its daylight part is time anyone can use, so that is the part reported
+        as a window, counted as rain hours, or rewarded with a duration bonus.
+        """
+        day_start = self.time.replace(
+            hour=DAYLIGHT_START_HOUR, minute=0, second=0, microsecond=0
+        )
+        day_end = self.time.replace(
+            hour=DAYLIGHT_END_HOUR, minute=0, second=0, microsecond=0
+        ) + timedelta(hours=1)
+        start = max(self.time, day_start)
+        end = min(self.end_time, day_end)
+        return start, max(start, end)
+
+    @property
+    def daylight_hours(self) -> int:
+        """Return how many usable daylight hours this entry offers."""
+        start, end = self.daylight_span
+        return int(round((end - start).total_seconds() / 3600))
 
     @property
     def has_core_readings(self) -> bool:
@@ -156,8 +185,12 @@ def _valid_temperatures(hours: list[HourlyWeather]) -> list[NumericType]:
 
 
 def _count_likely_rain_hours(hours: list[HourlyWeather]) -> int:
-    """Count the hours covered by entries above the rain threshold."""
-    return sum(hour.coverage_hours for hour in hours if _has_significant_rain(hour))
+    """Count the usable daylight hours likely to be rained on.
+
+    Counting an entry's whole span would report more rain hours than the day
+    has daylight, because a six-hour entry can hang off either end of it.
+    """
+    return sum(hour.daylight_hours for hour in hours if _has_significant_rain(hour))
 
 
 def _has_significant_rain(hour: HourlyWeather) -> bool:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -56,6 +56,20 @@ class HourlyWeather:
         return self.coverage_hours == 1
 
     @property
+    def has_core_readings(self) -> bool:
+        """Return True when the readings a recommendation depends on are present.
+
+        A missing reading scores as zero, which is indistinguishable from a
+        mediocre real one. Rather than let a gap in the data masquerade as
+        weather, entries missing a core reading are shown but never form the
+        basis of a recommendation.
+        """
+        return all(
+            value is not None
+            for value in (self.temp, self.wind, self.precipitation_amount)
+        )
+
+    @property
     def precipitation_rate(self) -> Optional[NumericType]:
         """Return precipitation in mm per hour.
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -4,7 +4,7 @@ Defines HourlyWeather and DailyReport classes used throughout the application.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 from src.core.config import NumericType, safe_average
@@ -29,6 +29,7 @@ class HourlyWeather:
     relative_humidity: Optional[NumericType] = None
     water_temp: Optional[NumericType] = None
     wave_height: Optional[NumericType] = None
+    coverage_hours: int = 1
     temp_score: NumericType = 0
     wind_score: NumericType = 0
     cloud_score: NumericType = 0
@@ -43,6 +44,28 @@ class HourlyWeather:
         """Calculate derived fields after initialization."""
         self.hour = self.time.hour
         self.total_score = self._calculate_total_score()
+
+    @property
+    def end_time(self) -> datetime:
+        """Return the first instant no longer described by this entry."""
+        return self.time + timedelta(hours=self.coverage_hours)
+
+    @property
+    def is_hourly(self) -> bool:
+        """Return True when this entry describes a single hour."""
+        return self.coverage_hours == 1
+
+    @property
+    def precipitation_rate(self) -> Optional[NumericType]:
+        """Return precipitation in mm per hour.
+
+        Beyond roughly two days the forecast only reports six-hour totals.
+        Scoring those totals as if they fell in one hour would exaggerate rain
+        on later days, so scores are always based on the hourly rate.
+        """
+        if self.precipitation_amount is None:
+            return None
+        return self.precipitation_amount / self.coverage_hours
 
     def _calculate_total_score(self) -> NumericType:
         """Calculate the total score from individual component scores."""
@@ -119,14 +142,14 @@ def _valid_temperatures(hours: list[HourlyWeather]) -> list[NumericType]:
 
 
 def _count_likely_rain_hours(hours: list[HourlyWeather]) -> int:
-    """Count hours with precipitation above the rain threshold."""
-    return sum(1 for hour in hours if _has_significant_rain(hour))
+    """Count the hours covered by entries above the rain threshold."""
+    return sum(hour.coverage_hours for hour in hours if _has_significant_rain(hour))
 
 
 def _has_significant_rain(hour: HourlyWeather) -> bool:
     """Return True when an hour is likely rainy."""
-    amount = hour.precipitation_amount
-    return isinstance(amount, (int, float)) and amount > SIGNIFICANT_RAIN_MM
+    rate = hour.precipitation_rate
+    return isinstance(rate, (int, float)) and rate > SIGNIFICANT_RAIN_MM
 
 
 def _describe_temperature(avg_temp: Optional[NumericType]) -> str:

--- a/src/core/scoring.py
+++ b/src/core/scoring.py
@@ -251,10 +251,35 @@ RATING_RANGES_BY_PROFILE = {
     ACTIVITY_BEACH_DAY: BEACH_RATING_RANGES,
 }
 
+def _best_possible(*range_lists: List[RangeType]) -> int:
+    """Return the highest score these ranges can award in total."""
+    return sum(max(score for _, score in ranges) for ranges in range_lists)
+
+
+# The best weather a profile can possibly describe. Deriving this rather than
+# hardcoding it keeps 100 meaning "as good as this activity gets" for every
+# profile; a stale constant previously capped perfect hiking weather at 96.
+MAX_HIKING_SCORE = _best_possible(
+    TEMP_RANGES,
+    WIND_RANGES,
+    CLOUD_RANGES,
+    PRECIP_AMOUNT_RANGES,
+    HUMIDITY_RANGES,
+    PRECIP_PROBABILITY_RANGES,
+)
+MAX_BEACH_SCORE = _best_possible(
+    BEACH_TEMP_RANGES,
+    BEACH_WIND_RANGES,
+    BEACH_CLOUD_RANGES,
+    BEACH_PRECIP_AMOUNT_RANGES,
+    BEACH_HUMIDITY_RANGES,
+    BEACH_PRECIP_PROBABILITY_RANGES,
+)
+
 # excellent, very_good, good, fair, max_expected, poor_slope
 NORMALIZATION_CONFIG_BY_PROFILE = {
-    ACTIVITY_HIKING: (18, 13, 7, 2, 23, 6),
-    ACTIVITY_BEACH_DAY: (22, 17, 11, 5, 26, 5),
+    ACTIVITY_HIKING: (18, 13, 7, 2, MAX_HIKING_SCORE, 6),
+    ACTIVITY_BEACH_DAY: (22, 17, 11, 5, MAX_BEACH_SCORE, 5),
 }
 
 

--- a/src/core/scoring.py
+++ b/src/core/scoring.py
@@ -392,6 +392,18 @@ def get_activity_profile_key(label: str) -> str:
     return DEFAULT_ACTIVITY_PROFILE
 
 
+def _hourly_precipitation_rate(hour: Any) -> Optional[NumericType]:
+    """Return an entry's precipitation as mm per hour.
+
+    Later forecast days only carry six-hour totals; scoring those directly
+    would treat a normal wet afternoon as a downpour.
+    """
+    rate = getattr(hour, "precipitation_rate", None)
+    if rate is not None:
+        return rate
+    return getattr(hour, "precipitation_amount", None)
+
+
 def get_activity_score(
     hour: Any, profile_key: str = DEFAULT_ACTIVITY_PROFILE
 ) -> NumericType:
@@ -401,7 +413,7 @@ def get_activity_score(
             hour.temp,
             hour.wind,
             hour.cloud_coverage,
-            hour.precipitation_amount,
+            _hourly_precipitation_rate(hour),
             hour.relative_humidity,
             getattr(hour, "precipitation_probability", None),
             getattr(hour, "symbol_code", None),

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -1031,7 +1031,7 @@ class WeatherHelperApp:
     def _format_block_details(self, best_block: dict[str, Any]) -> str:
         """Return details text for a recommended block."""
         start_str = format_time(best_block["start"])
-        end_str = format_time(best_block["end"] + timedelta(hours=1))
+        end_str = format_time(best_block["end_time"])
         detail_lines = [
             f"Best time: {start_str} - {end_str}",
             f"Temp: {format_temperature(best_block.get('temp'))}",

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -7,7 +7,7 @@ import threading
 import tkinter as tk
 import tkinter.messagebox as messagebox
 import webbrowser
-from datetime import date, timedelta
+from datetime import date
 from tkinter import ttk
 from typing import Any, Dict
 

--- a/src/mobile/app.py
+++ b/src/mobile/app.py
@@ -7,7 +7,7 @@ on screen is traceable to the hours listed inside the card that produced it.
 
 import asyncio
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from importlib import import_module
 from typing import Any, Callable, Optional
 
@@ -26,7 +26,6 @@ from src.core.config import (
     DAYLIGHT_START_HOUR,
     MET_NORWAY_LICENSE_URL,
     MET_NORWAY_SOURCE_URL,
-    get_current_date,
 )
 from src.core.locations import LOCATION_GROUPS
 from src.core.scoring import ACTIVITY_PROFILE_LABELS
@@ -101,6 +100,7 @@ class _Screen:
         self.model = model
         self.palette = Palette(dark=self._prefers_dark())
         self._load_generation = 0
+        self._in_flight_generation = 0
         self._expanded_keys: set[str] = set()
 
     # --- Colour and theme -------------------------------------------------
@@ -149,7 +149,9 @@ class _Screen:
             **kwargs,
         )
 
-    def _metric(self, metric: "_Metric", value: Optional[float]) -> Any:
+    def _metric(
+        self, metric: "_Metric", value: Optional[float], *, unit: Optional[str] = None
+    ) -> Any:
         """Render one weather reading with its icon and an accessible label.
 
         A missing reading keeps the muted colour and a dash. It is never given
@@ -158,7 +160,12 @@ class _Screen:
         """
         ft = self.ft
         missing = value is None
-        text = format_optional(value, metric.formatter)
+        formatter = (
+            metric.formatter
+            if unit is None
+            else (lambda reading: metric.formatter(reading, unit))
+        )
+        text = format_optional(value, formatter)
         colour = self.palette.text_secondary if missing else self.palette.text
         described = f"{metric.label}: {text if not missing else 'not available'}"
         return ft.Row(
@@ -678,7 +685,11 @@ class _Screen:
                                     self._metric(TEMPERATURE, row.temperature),
                                     self._metric(WIND, row.wind),
                                     self._metric(CLOUDS, row.clouds),
-                                    self._metric(RAIN, row.precipitation),
+                                    self._metric(
+                                        RAIN,
+                                        row.precipitation,
+                                        unit=row.precipitation_unit,
+                                    ),
                                     self._metric(HUMIDITY, row.humidity),
                                 ],
                             ),
@@ -742,11 +753,11 @@ class _Screen:
     def _selected_day_label(self) -> str:
         if self.model.selected_date is None:
             return "today"
-        return format_relative_date(self.model.selected_date, get_current_date())
+        return format_relative_date(self.model.selected_date, _device_today())
 
     def _update_date_options(self) -> None:
         ft = self.ft
-        today = get_current_date()
+        today = _device_today()
         available_dates = self.model.available_dates()
         self.date_dropdown.options = [
             ft.DropdownOption(
@@ -839,19 +850,32 @@ class _Screen:
         """Reload the selected region, ignoring results from a superseded load."""
         self._load_generation += 1
         generation = self._load_generation
+        self._in_flight_generation = generation
         self._set_loading(True)
         self.status.value = f"Loading {self.model.group_name}…"
         self.page.update()
 
+        async def show_progress(current: int, total: int) -> None:
+            # A progress update can be delivered after its load has finished;
+            # it must never overwrite the final result with a stale count.
+            if generation == self._in_flight_generation:
+                self.status.value = (
+                    f"Loading {self.model.group_name}… {current}/{total}"
+                )
+                self.page.update()
+
         def report_progress(current: int, total: int, location: Any) -> None:
-            if generation == self._load_generation:
-                self.status.value = f"Loading {self.model.group_name}… {current}/{total}"
+            # Called from a worker thread; run_task hands the update back to
+            # the page's event loop so the counter is actually painted.
+            if generation == self._in_flight_generation:
+                self.page.run_task(show_progress, current, total)
 
         try:
             self.model.invalidate_rankings()
             batch = await asyncio.to_thread(self.model.load, report_progress)
         except Exception:
             if generation == self._load_generation:
+                self._in_flight_generation = 0
                 self.status.value = (
                     "Could not load forecasts. Check your connection and try again."
                 )
@@ -862,6 +886,7 @@ class _Screen:
         if generation != self._load_generation:
             return  # A newer load is already in flight; its result wins.
 
+        self._in_flight_generation = 0
         self.status.value = _load_summary(batch, self.model.group_name)
         self._set_loading(False)
         self.render_dashboard()
@@ -901,6 +926,16 @@ class _Screen:
 
         if initial_load:
             self.page.run_task(self.refresh_forecast)
+
+
+def _device_today() -> date:
+    """Return today's date on this device.
+
+    "Today" and "Tomorrow" describe where the person reading the screen is,
+    not the application's fallback time zone, which would mislabel a day in a
+    region on the other side of the world.
+    """
+    return datetime.now().date()
 
 
 def _rating_for_rank_marker(rank: int) -> str:

--- a/src/mobile/app.py
+++ b/src/mobile/app.py
@@ -332,7 +332,12 @@ class _Screen:
                             ),
                         ],
                     ),
-                    self._score_badge(best.normalized_score, best.rating, large=True),
+                    self._score_badge(
+                        best.window_score,
+                        best.window_rating,
+                        caption="this window",
+                        large=True,
+                    ),
                 ],
             ),
             self._secondary(best.best_window_details, size=BODY_SIZE),
@@ -341,7 +346,8 @@ class _Screen:
                 bgcolor=self.palette.rating_background(best.rating),
                 border_radius=8,
                 content=self._text(
-                    f"{best.rating} · {best.weather_description}",
+                    f"Rest of the day: {best.rating.lower()} "
+                    f"({best.normalized_score}/100) · {best.weather_description}",
                     size=LABEL_SIZE,
                     color=colour,
                     weight=ft.FontWeight.BOLD,
@@ -350,32 +356,45 @@ class _Screen:
         ]
 
     def _score_badge(
-        self, score: Optional[int], rating: str, *, large: bool = False
+        self,
+        score: Optional[int],
+        rating: str,
+        *,
+        caption: str = "",
+        large: bool = False,
     ) -> Any:
-        """Render a score as a number out of 100 with its rating word."""
+        """Render a score out of 100 with its rating word and what it measures.
+
+        Every score on screen states its scale and its subject, so a number
+        printed beside a time is never mistaken for a claim about something
+        else.
+        """
         ft = self.ft
         colour = self.palette.rating(rating)
+        controls = [
+            ft.Row(
+                spacing=1,
+                tight=True,
+                vertical_alignment=ft.CrossAxisAlignment.END,
+                controls=[
+                    self._text(
+                        MISSING_VALUE if score is None else str(score),
+                        size=HEADLINE_SIZE if large else SUBTITLE_SIZE + 3,
+                        weight=ft.FontWeight.BOLD,
+                        color=colour,
+                    ),
+                    self._secondary("/100", size=LABEL_SIZE - 1),
+                ],
+            ),
+            self._text(rating, size=LABEL_SIZE, color=colour),
+        ]
+        if caption:
+            controls.append(self._secondary(caption, size=LABEL_SIZE - 2))
         return ft.Column(
             horizontal_alignment=ft.CrossAxisAlignment.END,
             spacing=0,
             tight=True,
-            controls=[
-                ft.Row(
-                    spacing=1,
-                    tight=True,
-                    vertical_alignment=ft.CrossAxisAlignment.END,
-                    controls=[
-                        self._text(
-                            MISSING_VALUE if score is None else str(score),
-                            size=HEADLINE_SIZE if large else SUBTITLE_SIZE + 3,
-                            weight=ft.FontWeight.BOLD,
-                            color=colour,
-                        ),
-                        self._secondary("/100", size=LABEL_SIZE - 1),
-                    ],
-                ),
-                self._text(rating, size=LABEL_SIZE, color=colour),
-            ],
+            controls=controls,
         )
 
     # --- Pinned locations -------------------------------------------------
@@ -476,6 +495,7 @@ class _Screen:
                     ],
                 ),
                 self._secondary(
+                    "Ordered by how settled the whole day looks. "
                     "Tap a location to see the hours behind its score."
                 ),
                 self.forecast_list,
@@ -516,11 +536,17 @@ class _Screen:
                 card.location_name, size=SUBTITLE_SIZE, weight=ft.FontWeight.BOLD
             ),
             subtitle=self._secondary(
-                card.best_window if card.is_ranked else "No window to recommend",
+                f"{card.best_window} · window {card.window_score}/100"
+                if card.is_ranked
+                else "No window to recommend",
                 size=BODY_SIZE,
             ),
             leading=self._rank_marker(rank, colour),
-            trailing=self._score_badge(card.normalized_score, card.rating),
+            # The list is ordered by how the day as a whole looks, so that is
+            # the score shown here; the window's own score is on the row above.
+            trailing=self._score_badge(
+                card.normalized_score, card.rating, caption="the day"
+            ),
             expanded=is_expanded,
             maintain_state=False,
             tile_padding=ft.Padding(left=SPACING, top=8, right=SPACING, bottom=8),

--- a/src/mobile/app.py
+++ b/src/mobile/app.py
@@ -1,32 +1,74 @@
-"""Responsive Flet interface for desktop previews and Android builds."""
+"""Responsive Flet interface for desktop previews and Android builds.
+
+The screen is built around one question: where should I go, and when. The
+answer is at the top in full, the ranked alternatives follow, and every score
+on screen is traceable to the hours listed inside the card that produced it.
+"""
 
 import asyncio
+from dataclasses import dataclass
 from datetime import date
 from importlib import import_module
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from src.application.presentation import (
-    BASE_COLORS,
-    get_rating_background as rating_background,
-    get_rating_color as rating_color,
+    MISSING_VALUE,
+    RATING_ORDER,
+    format_optional,
+    format_percentage,
+    format_precipitation,
+    format_relative_date,
+    format_temperature,
+    format_wind_speed,
 )
-from src.core.config import MET_NORWAY_LICENSE_URL, MET_NORWAY_SOURCE_URL
+from src.core.config import (
+    DAYLIGHT_END_HOUR,
+    DAYLIGHT_START_HOUR,
+    MET_NORWAY_LICENSE_URL,
+    MET_NORWAY_SOURCE_URL,
+    get_current_date,
+)
 from src.core.locations import LOCATION_GROUPS
 from src.core.scoring import ACTIVITY_PROFILE_LABELS
-from src.mobile.view_model import MobileWeatherViewModel, RankedLocationView
-
-BACKGROUND_COLOR = BASE_COLORS["background"]
-SURFACE_COLOR = BASE_COLORS["surface"]
-TEXT_COLOR = BASE_COLORS["text"]
-TEXT_SECONDARY_COLOR = BASE_COLORS["text_secondary"]
-PRIMARY_COLOR = BASE_COLORS["primary"]
-BORDER_COLOR = "#cbd5e1"
+from src.mobile.theme import (
+    BODY_SIZE,
+    CARD_RADIUS,
+    HEADLINE_SIZE,
+    LABEL_SIZE,
+    SPACING,
+    SUBTITLE_SIZE,
+    TITLE_SIZE,
+    Palette,
+)
+from src.mobile.view_model import (
+    HourlyForecastView,
+    MobileWeatherViewModel,
+    RankedLocationView,
+)
 
 FLET_INSTALL_HINT = (
     "Flet is not installed in the active environment. Activate a project virtual "
     "environment, install the mobile extra with `python -m pip install -e "
     "\".[mobile]\"`, then run `flet run weather_helper_mobile.py`."
 )
+
+RANKED_LOCATION_COUNT = 10
+
+
+@dataclass(frozen=True)
+class _Metric:
+    """One weather reading: its icon, its spoken label and its formatter."""
+
+    icon: str
+    label: str
+    formatter: Any
+
+
+TEMPERATURE = _Metric("THERMOSTAT", "Temperature", format_temperature)
+WIND = _Metric("AIR", "Wind", format_wind_speed)
+CLOUDS = _Metric("CLOUD_QUEUE", "Cloud cover", format_percentage)
+RAIN = _Metric("WATER_DROP_OUTLINED", "Precipitation", format_precipitation)
+HUMIDITY = _Metric("WATER", "Humidity", format_percentage)
 
 
 def _load_flet():
@@ -36,615 +78,822 @@ def _load_flet():
         raise RuntimeError(FLET_INSTALL_HINT) from exc
 
 
-def _get_cloud_icon(ft: Any, cloud_str: str) -> Any:
-    try:
-        val = float(cloud_str.replace('%', '').strip())
-        if val < 20: return ft.Icon(ft.Icons.WB_SUNNY, color=ft.Colors.YELLOW_600, size=15)
-        elif val < 60: return ft.Icon(ft.Icons.CLOUD_QUEUE, color=ft.Colors.GREY_400, size=15)
-        else: return ft.Icon(ft.Icons.CLOUD, color=ft.Colors.GREY_500, size=15)
-    except Exception:
-        return ft.Icon(ft.Icons.CLOUD, color=ft.Colors.GREY_500, size=15)
-
-def _get_rain_icon(ft: Any, rain_str: str) -> Any:
-    try:
-        val = float(rain_str.split()[0])
-        if val == 0: return ft.Icon(ft.Icons.WATER_DROP_OUTLINED, color=ft.Colors.GREY_400, size=15)
-        elif val < 2.0: return ft.Icon(ft.Icons.WATER_DROP, color=ft.Colors.LIGHT_BLUE_400, size=15)
-        else: return ft.Icon(ft.Icons.WATER_DROP, color=ft.Colors.BLUE_600, size=15)
-    except Exception:
-        return ft.Icon(ft.Icons.WATER_DROP, color=ft.Colors.BLUE_600, size=15)
-
-def _get_wind_icon(ft: Any, wind_str: str) -> Any:
-    try:
-        val = float(wind_str.split()[0])
-        if val < 3: return ft.Icon(ft.Icons.AIR, color=ft.Colors.GREY_400, size=15)
-        elif val < 8: return ft.Icon(ft.Icons.AIR, color=ft.Colors.BLUE_400, size=15)
-        else: return ft.Icon(ft.Icons.WIND_POWER, color=ft.Colors.BLUE_600, size=15)
-    except Exception:
-        return ft.Icon(ft.Icons.AIR, color=ft.Colors.GREY_400, size=15)
-
-def _get_temp_icon(ft: Any, temp_str: str) -> Any:
-    try:
-        val = float(temp_str.split()[0])
-        if val < 10: return ft.Icon(ft.Icons.THERMOSTAT, color=ft.Colors.BLUE_400, size=15)
-        elif val < 25: return ft.Icon(ft.Icons.THERMOSTAT, color=ft.Colors.ORANGE_400, size=15)
-        else: return ft.Icon(ft.Icons.THERMOSTAT, color=ft.Colors.RED_400, size=15)
-    except Exception:
-        return ft.Icon(ft.Icons.THERMOSTAT, color=ft.Colors.ORANGE_400, size=15)
-
-def _get_humidity_icon(ft: Any, hum_str: str) -> Any:
-    return ft.Icon(ft.Icons.WATER, color=ft.Colors.LIGHT_BLUE_400, size=15)
-
-def _get_activity_icon_name(profile_key: str) -> str:
-    return "BEACH_ACCESS" if profile_key == "beach_day" else "HIKING"
-
-
 def create_mobile_app(
     page: Any,
     *,
     ft: Any = None,
     view_model: Optional[MobileWeatherViewModel] = None,
 ) -> None:
-    """Build a single-scroll forecast overview: filters, daily plan, and a
-    ranked location list whose entries expand in place for full detail."""
+    """Build the forecast screen: today's answer, then the ranked alternatives."""
     ft = ft or _load_flet()
     assert ft is not None
     model = view_model or MobileWeatherViewModel()
+    screen = _Screen(page, ft, model)
+    screen.build()
 
-    page.title = "Weather Helper"
-    page.theme_mode = ft.ThemeMode.LIGHT
-    page.padding = 0
-    page.bgcolor = BACKGROUND_COLOR
 
-    status = ft.Text(
-        "Loading the default Asturias forecast…",
-        color=TEXT_SECONDARY_COLOR,
-        size=13,
-    )
-    progress = ft.ProgressBar(visible=False)
-    forecast_list = ft.Column(spacing=10)
-    daily_summary = ft.Column(spacing=4)
+class _Screen:
+    """Owns the Flet controls and keeps them in step with the view model."""
 
-    # --- Styled dropdowns with increased font and padding ---
+    def __init__(self, page: Any, ft: Any, model: MobileWeatherViewModel) -> None:
+        self.page = page
+        self.ft = ft
+        self.model = model
+        self.palette = Palette(dark=self._prefers_dark())
+        self._load_generation = 0
+        self._expanded_keys: set[str] = set()
 
-    def style_dropdown(dd: Any) -> Any:
-        dd.dense = True
-        dd.border_radius = 10
-        dd.content_padding = 12
-        dd.border_color = BORDER_COLOR
-        dd.text_size = 15
-        dd.expand = True
-        return dd
+    # --- Colour and theme -------------------------------------------------
 
-    group_dropdown = style_dropdown(ft.Dropdown(
-        label="Region",
-        value=model.group_name,
-        options=[ft.DropdownOption(key=name, text=name) for name in LOCATION_GROUPS],
-    ))
-    location_dropdown = style_dropdown(ft.Dropdown(
-        label="Location",
-        disabled=True,
-        options=[],
-        hint_text="Loading locations…",
-    ))
-    profile_dropdown = style_dropdown(ft.Dropdown(
-        label="Activity",
-        value=model.activity_profile,
-        options=[
-            ft.DropdownOption(key=key, text=label)
-            for key, label in ACTIVITY_PROFILE_LABELS.items()
-        ],
-    ))
-    date_dropdown = style_dropdown(ft.Dropdown(label="Date", disabled=True, options=[]))
+    def _prefers_dark(self) -> bool:
+        """Return True when the device is currently in dark mode."""
+        ft = self.ft
+        return getattr(self.page, "platform_brightness", None) == ft.Brightness.DARK
 
-    refresh_button = ft.IconButton(
-        icon=ft.Icons.REFRESH,
-        icon_color=ft.Colors.WHITE,
-        icon_size=22,
-        tooltip="Refresh forecast",
-    )
+    def _apply_theme(self) -> None:
+        ft = self.ft
+        self.page.theme_mode = ft.ThemeMode.SYSTEM
+        self.page.bgcolor = self.palette.background
 
-    def elevated_card(content: Any, *, padding: int = 14) -> Any:
-        """Wrap content in a consistently elevated, rounded surface."""
-        return ft.Container(
-            padding=padding,
-            bgcolor=SURFACE_COLOR,
-            border_radius=14,
-            shadow=ft.BoxShadow(
-                spread_radius=0,
-                blur_radius=10,
-                color=ft.Colors.with_opacity(0.08, "#0f172a"),
-                offset=ft.Offset(0, 2),
-            ),
-            content=content,
+    # --- Small shared building blocks -------------------------------------
+
+    def _text(
+        self,
+        value: str,
+        *,
+        size: int = BODY_SIZE,
+        color: Optional[str] = None,
+        weight: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        ft = self.ft
+        return ft.Text(
+            value,
+            size=size,
+            color=color or self.palette.text,
+            weight=weight or ft.FontWeight.NORMAL,
+            **kwargs,
         )
 
-    # --- Hourly forecast rows (shared by every expanded location card) ---
+    def _secondary(self, value: str, *, size: int = LABEL_SIZE, **kwargs: Any) -> Any:
+        return self._text(value, size=size, color=self.palette.text_secondary, **kwargs)
 
-    def hourly_row(row: Any) -> Any:
+    def _card(self, content: Any, *, padding: int = SPACING + 2, **kwargs: Any) -> Any:
+        ft = self.ft
         return ft.Container(
-            padding=ft.Padding(left=0, top=10, right=12, bottom=10),
-            bgcolor=BACKGROUND_COLOR,
+            padding=padding,
+            bgcolor=self.palette.surface,
+            border_radius=CARD_RADIUS,
+            border=ft.Border.all(1, self.palette.border),
+            content=content,
+            **kwargs,
+        )
+
+    def _metric(self, metric: "_Metric", value: Optional[float]) -> Any:
+        """Render one weather reading with its icon and an accessible label.
+
+        A missing reading keeps the muted colour and a dash. It is never given
+        the appearance of a real value, which is what previously made an
+        absent rainfall figure look like heavy rain.
+        """
+        ft = self.ft
+        missing = value is None
+        text = format_optional(value, metric.formatter)
+        colour = self.palette.text_secondary if missing else self.palette.text
+        described = f"{metric.label}: {text if not missing else 'not available'}"
+        return ft.Row(
+            spacing=4,
+            tight=True,
+            tooltip=described,
+            controls=[
+                ft.Icon(
+                    getattr(ft.Icons, metric.icon),
+                    size=16,
+                    color=self.palette.text_secondary,
+                    semantics_label=metric.label,
+                ),
+                self._text(text, size=LABEL_SIZE, color=colour, semantics_label=described),
+            ],
+        )
+
+    # --- Header -----------------------------------------------------------
+
+    def _build_header(self) -> Any:
+        ft = self.ft
+        self.refresh_button = ft.IconButton(
+            icon=ft.Icons.REFRESH,
+            icon_color=ft.Colors.WHITE,
+            icon_size=24,
+            tooltip="Refresh forecast",
+            on_click=self.on_refresh_click,
+        )
+        self.page.appbar = ft.AppBar(
+            title=ft.Text(
+                "Weather Helper",
+                weight=ft.FontWeight.BOLD,
+                size=TITLE_SIZE,
+                color=ft.Colors.WHITE,
+            ),
+            center_title=False,
+            bgcolor=self.palette.primary,
+            color=ft.Colors.WHITE,
+            actions=[self.refresh_button],
+        )
+
+    # --- Status -----------------------------------------------------------
+
+    def _build_status(self) -> Any:
+        ft = self.ft
+        self.status = self._secondary("Loading forecasts…", size=BODY_SIZE)
+        self.freshness = self._secondary("")
+        self.progress = ft.ProgressBar(visible=False, color=self.palette.primary)
+        self.status_row = ft.Column(
+            spacing=4,
+            controls=[self.status, self.freshness, self.progress],
+        )
+        return self.status_row
+
+    # --- Filters ----------------------------------------------------------
+
+    def _style_dropdown(self, dropdown: Any) -> Any:
+        dropdown.border_radius = 10
+        dropdown.content_padding = SPACING
+        dropdown.border_color = self.palette.border
+        dropdown.text_size = BODY_SIZE
+        dropdown.color = self.palette.text
+        dropdown.expand = True
+        return dropdown
+
+    def _build_filters(self) -> Any:
+        ft = self.ft
+        self.group_dropdown = self._style_dropdown(
+            ft.Dropdown(
+                label="Region",
+                value=self.model.group_name,
+                options=[
+                    ft.DropdownOption(key=name, text=name) for name in LOCATION_GROUPS
+                ],
+                on_select=self.on_group_select,
+            )
+        )
+        self.date_dropdown = self._style_dropdown(
+            ft.Dropdown(label="Day", disabled=True, options=[], on_select=self.on_date_select)
+        )
+        self.profile_dropdown = self._style_dropdown(
+            ft.Dropdown(
+                label="Activity",
+                value=self.model.activity_profile,
+                options=[
+                    ft.DropdownOption(key=key, text=label)
+                    for key, label in ACTIVITY_PROFILE_LABELS.items()
+                ],
+                on_select=self.on_profile_select,
+            )
+        )
+        return self._card(
+            ft.ResponsiveRow(
+                columns=12,
+                spacing=8,
+                run_spacing=8,
+                controls=[
+                    ft.Container(col={"xs": 12, "sm": 4}, content=self.group_dropdown),
+                    ft.Container(col={"xs": 6, "sm": 4}, content=self.date_dropdown),
+                    ft.Container(col={"xs": 6, "sm": 4}, content=self.profile_dropdown),
+                ],
+            ),
+            padding=SPACING,
+        )
+
+    # --- The answer -------------------------------------------------------
+
+    def _build_headline(self) -> Any:
+        self.headline = self.ft.Column(spacing=6)
+        self.headline_card = self._card(self.headline)
+        return self.headline_card
+
+    def render_headline(self) -> None:
+        """Render the single best recommendation as the top of the screen."""
+        ft = self.ft
+        best = self.model.top_recommendation()
+        activity = self.model.activity_label()
+        day = self._selected_day_label()
+
+        if best is None:
+            self.headline.controls = [
+                self._text(
+                    f"No {activity.lower()} window worth recommending {day.lower()}",
+                    size=SUBTITLE_SIZE,
+                    weight=ft.FontWeight.BOLD,
+                ),
+                self._secondary(
+                    "Nothing in this region scores well enough for this activity. "
+                    "Try another day, activity or region.",
+                    size=BODY_SIZE,
+                ),
+            ]
+            self.headline_card.bgcolor = self.palette.surface
+            return
+
+        colour = self.palette.rating(best.rating)
+        self.headline.controls = [
+            self._secondary(f"Best for {activity.lower()} · {day}"),
+            ft.Row(
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                spacing=SPACING,
+                controls=[
+                    ft.Column(
+                        expand=True,
+                        spacing=2,
+                        controls=[
+                            self._text(
+                                best.location_name,
+                                size=HEADLINE_SIZE,
+                                weight=ft.FontWeight.BOLD,
+                            ),
+                            ft.Row(
+                                spacing=6,
+                                controls=[
+                                    ft.Icon(
+                                        ft.Icons.SCHEDULE,
+                                        size=20,
+                                        color=self.palette.text,
+                                    ),
+                                    self._text(
+                                        best.best_window,
+                                        size=SUBTITLE_SIZE,
+                                        weight=ft.FontWeight.BOLD,
+                                    ),
+                                    self._secondary(
+                                        f"({best.window_length_label})"
+                                        if best.window_length_label
+                                        else ""
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    self._score_badge(best.normalized_score, best.rating, large=True),
+                ],
+            ),
+            self._secondary(best.best_window_details, size=BODY_SIZE),
+            ft.Container(
+                padding=ft.Padding(left=10, top=6, right=10, bottom=6),
+                bgcolor=self.palette.rating_background(best.rating),
+                border_radius=8,
+                content=self._text(
+                    f"{best.rating} · {best.weather_description}",
+                    size=LABEL_SIZE,
+                    color=colour,
+                    weight=ft.FontWeight.BOLD,
+                ),
+            ),
+        ]
+
+    def _score_badge(
+        self, score: Optional[int], rating: str, *, large: bool = False
+    ) -> Any:
+        """Render a score as a number out of 100 with its rating word."""
+        ft = self.ft
+        colour = self.palette.rating(rating)
+        return ft.Column(
+            horizontal_alignment=ft.CrossAxisAlignment.END,
+            spacing=0,
+            tight=True,
+            controls=[
+                ft.Row(
+                    spacing=1,
+                    tight=True,
+                    vertical_alignment=ft.CrossAxisAlignment.END,
+                    controls=[
+                        self._text(
+                            MISSING_VALUE if score is None else str(score),
+                            size=HEADLINE_SIZE if large else SUBTITLE_SIZE + 3,
+                            weight=ft.FontWeight.BOLD,
+                            color=colour,
+                        ),
+                        self._secondary("/100", size=LABEL_SIZE - 1),
+                    ],
+                ),
+                self._text(rating, size=LABEL_SIZE, color=colour),
+            ],
+        )
+
+    # --- Pinned locations -------------------------------------------------
+
+    def _build_pinned(self) -> Any:
+        self.pinned = self.ft.Column(spacing=8)
+        self.pinned_card = self._card(self.pinned)
+        return self.pinned_card
+
+    def render_pinned(self) -> None:
+        """Render the pinned locations for the current region, if any."""
+        ft = self.ft
+        rows = self.model.daily_summary_rows()
+        names = self.model.priority_location_names()
+        if not rows:
+            self.pinned_card.visible = False
+            return
+
+        self.pinned_card.visible = True
+        heading = (
+            f"{' and '.join(names)} · {self.model.activity_label().lower()}"
+            if names
+            else f"Best alternatives for {self.model.activity_label().lower()}"
+        )
+        controls: list[Any] = [
+            ft.Row(
+                spacing=6,
+                controls=[
+                    ft.Icon(ft.Icons.PUSH_PIN_OUTLINED, size=18, color=self.palette.primary),
+                    self._text(heading, size=SUBTITLE_SIZE, weight=ft.FontWeight.BOLD),
+                ],
+            )
+        ]
+        alternatives_started = False
+        for row in rows:
+            if not row.is_priority and not alternatives_started and names:
+                controls.append(
+                    self._secondary("Better elsewhere today", size=LABEL_SIZE)
+                )
+                alternatives_started = True
+            controls.append(self._pinned_row(row))
+        self.pinned.controls = controls
+
+    def _pinned_row(self, row: Any) -> Any:
+        ft = self.ft
+        unavailable = row.normalized_score is None
+        return ft.Row(
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            spacing=8,
+            controls=[
+                ft.Container(
+                    expand=True,
+                    content=self._text(row.location_name, size=BODY_SIZE),
+                ),
+                self._text(
+                    row.best_window,
+                    size=BODY_SIZE,
+                    color=(
+                        self.palette.text_secondary if unavailable else self.palette.text
+                    ),
+                ),
+                ft.Container(
+                    width=52,
+                    alignment=ft.Alignment.CENTER_RIGHT,
+                    content=self._text(
+                        MISSING_VALUE if unavailable else str(row.normalized_score),
+                        size=BODY_SIZE,
+                        weight=ft.FontWeight.BOLD,
+                        color=self.palette.text_secondary
+                        if unavailable
+                        else self.palette.primary,
+                    ),
+                ),
+            ],
+        )
+
+    # --- Ranked list ------------------------------------------------------
+
+    def _build_ranking(self) -> Any:
+        ft = self.ft
+        self.forecast_list = ft.Column(spacing=10)
+        return ft.Column(
+            spacing=6,
+            controls=[
+                ft.Row(
+                    spacing=6,
+                    controls=[
+                        ft.Icon(
+                            ft.Icons.LEADERBOARD,
+                            size=18,
+                            color=self.palette.primary,
+                        ),
+                        self._text(
+                            "All locations, ranked",
+                            size=SUBTITLE_SIZE,
+                            weight=ft.FontWeight.BOLD,
+                        ),
+                    ],
+                ),
+                self._secondary(
+                    "Tap a location to see the hours behind its score."
+                ),
+                self.forecast_list,
+            ],
+        )
+
+    def render_forecast_list(self) -> None:
+        ranked = self.model.ranked_locations(RANKED_LOCATION_COUNT)
+        selected = self.model.selected_location()
+        ranked_keys = {card.location_key for card in ranked}
+
+        tiles = [
+            self._location_tile(card, rank=index)
+            for index, card in enumerate(ranked, 1)
+        ]
+        if selected is not None and selected.location_key not in ranked_keys:
+            # An explicitly chosen location stays reachable, but below the
+            # ranking rather than pretending to lead it.
+            tiles.append(self._location_tile(selected, rank=None))
+
+        self.forecast_list.controls = tiles or [
+            self._secondary(
+                "No location has usable forecast data for this day.",
+                size=BODY_SIZE,
+            )
+        ]
+
+    def _location_tile(self, card: RankedLocationView, *, rank: Optional[int]) -> Any:
+        ft = self.ft
+        colour = self.palette.rating(card.rating)
+        is_expanded = card.location_key in self._expanded_keys
+
+        def on_change(event: Any) -> None:
+            self.on_tile_toggle(card.location_key, bool(event.data))
+
+        tile = ft.ExpansionTile(
+            title=self._text(
+                card.location_name, size=SUBTITLE_SIZE, weight=ft.FontWeight.BOLD
+            ),
+            subtitle=self._secondary(
+                card.best_window if card.is_ranked else "No window to recommend",
+                size=BODY_SIZE,
+            ),
+            leading=self._rank_marker(rank, colour),
+            trailing=self._score_badge(card.normalized_score, card.rating),
+            expanded=is_expanded,
+            maintain_state=False,
+            tile_padding=ft.Padding(left=SPACING, top=8, right=SPACING, bottom=8),
+            collapsed_bgcolor=ft.Colors.TRANSPARENT,
+            bgcolor=ft.Colors.TRANSPARENT,
+            icon_color=colour,
+            collapsed_icon_color=self.palette.text_secondary,
+            on_change=on_change,
+            # Bodies are built only for the card the user opened; building all
+            # ten with their hourly rows made every filter change stutter.
+            controls=self._expanded_body(card) if is_expanded else [],
+        )
+        return ft.Container(
+            key=ft.ScrollKey(f"card_{card.location_key}"),
+            bgcolor=self.palette.surface,
+            border=ft.Border.all(
+                2 if is_expanded else 1,
+                colour if is_expanded else self.palette.border,
+            ),
+            border_radius=CARD_RADIUS,
+            clip_behavior=ft.ClipBehavior.ANTI_ALIAS,
+            content=tile,
+        )
+
+    def _rank_marker(self, rank: Optional[int], colour: str) -> Any:
+        ft = self.ft
+        if rank is None:
+            return ft.Icon(
+                ft.Icons.PLACE_OUTLINED, color=self.palette.text_secondary, size=22
+            )
+        return ft.Container(
+            width=30,
+            height=30,
+            alignment=ft.Alignment.CENTER,
+            bgcolor=self.palette.rating_background(
+                _rating_for_rank_marker(rank)
+            ),
+            border=ft.Border.all(1, colour),
+            border_radius=15,
+            content=self._text(
+                str(rank), size=LABEL_SIZE, weight=ft.FontWeight.BOLD, color=colour
+            ),
+        )
+
+    def _expanded_body(self, card: RankedLocationView) -> list[Any]:
+        ft = self.ft
+        rows = self.model.hourly_forecast(card.location_key)
+        if rows:
+            hours_note = (
+                f"Hours considered ({DAYLIGHT_START_HOUR:02d}:00–"
+                f"{DAYLIGHT_END_HOUR:02d}:00, upcoming only)"
+            )
+            body: list[Any] = [self._secondary(hours_note)]
+            body.extend(self._hourly_row(row) for row in rows)
+        else:
+            body = [
+                self._secondary(
+                    "No upcoming daylight hours left for this day.", size=BODY_SIZE
+                )
+            ]
+
+        return [
+            ft.Container(
+                padding=ft.Padding(left=SPACING, top=0, right=SPACING, bottom=SPACING),
+                content=ft.Column(
+                    spacing=6,
+                    controls=[
+                        ft.Divider(height=1, color=self.palette.border),
+                        self._secondary(card.best_window_details, size=BODY_SIZE),
+                        ft.Container(height=2),
+                        *body,
+                    ],
+                ),
+            )
+        ]
+
+    def _hourly_row(self, row: HourlyForecastView) -> Any:
+        """Render one forecast entry, marking the recommended window."""
+        ft = self.ft
+        colour = self.palette.rating(row.rating)
+        highlighted = row.in_best_window
+        time_line: list[Any] = [
+            self._text(
+                row.time,
+                size=SUBTITLE_SIZE,
+                weight=ft.FontWeight.BOLD,
+            )
+        ]
+        if not row.is_hourly:
+            time_line.append(self._secondary(row.span_label))
+        if highlighted:
+            time_line.append(
+                ft.Container(
+                    padding=ft.Padding(left=6, top=1, right=6, bottom=1),
+                    bgcolor=colour,
+                    border_radius=6,
+                    content=ft.Text(
+                        "BEST",
+                        size=LABEL_SIZE - 3,
+                        weight=ft.FontWeight.BOLD,
+                        color=self.palette.surface,
+                    ),
+                )
+            )
+
+        return ft.Container(
+            padding=ft.Padding(left=0, top=8, right=10, bottom=8),
+            bgcolor=(
+                self.palette.rating_background(row.rating)
+                if highlighted
+                else self.palette.background
+            ),
             border_radius=10,
             content=ft.Row(
                 vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 spacing=0,
                 controls=[
-                    ft.Container(
-                        width=5,
-                        height=70,
-                        bgcolor=rating_color(row.rating),
-                        border_radius=ft.BorderRadius(
-                            top_left=10, bottom_left=10,
-                            top_right=0, bottom_right=0,
-                        ),
-                    ),
+                    ft.Container(width=5, height=64, bgcolor=colour),
                     ft.Container(width=10),
                     ft.Column(
                         expand=True,
-                        spacing=2,
+                        spacing=3,
                         controls=[
-                            ft.Text(
-                                row.time,
-                                size=17,
-                                weight=ft.FontWeight.BOLD,
-                                color=TEXT_COLOR,
-                            ),
+                            ft.Row(spacing=6, controls=time_line),
                             ft.Row(
-                                spacing=4,
+                                spacing=10,
+                                wrap=True,
                                 controls=[
-                                    _get_temp_icon(ft, row.temperature),
-                                    ft.Text(f"{row.temperature}", size=14, color=TEXT_COLOR),
-                                    ft.Container(width=8),
-                                    _get_wind_icon(ft, row.wind),
-                                    ft.Text(f"{row.wind}", size=14, color=TEXT_COLOR),
-                                ],
-                            ),
-                            ft.Row(
-                                spacing=4,
-                                controls=[
-                                    _get_cloud_icon(ft, row.clouds),
-                                    ft.Text(f"{row.clouds}", size=13, color=TEXT_SECONDARY_COLOR),
-                                    ft.Container(width=4),
-                                    _get_rain_icon(ft, row.precipitation),
-                                    ft.Text(f"{row.precipitation}", size=13, color=TEXT_SECONDARY_COLOR),
-                                    ft.Container(width=4),
-                                    _get_humidity_icon(ft, row.humidity),
-                                    ft.Text(f"{row.humidity}", size=13, color=TEXT_SECONDARY_COLOR),
+                                    self._metric(TEMPERATURE, row.temperature),
+                                    self._metric(WIND, row.wind),
+                                    self._metric(CLOUDS, row.clouds),
+                                    self._metric(RAIN, row.precipitation),
+                                    self._metric(HUMIDITY, row.humidity),
                                 ],
                             ),
                         ],
                     ),
-                    ft.Column(
-                        horizontal_alignment=ft.CrossAxisAlignment.END,
-                        spacing=0,
-                        controls=[
-                            ft.Text(
-                                f"{row.normalized_score}",
-                                size=20,
-                                weight=ft.FontWeight.BOLD,
-                                color=rating_color(row.rating),
-                            ),
-                            ft.Text(
-                                row.rating,
-                                size=11,
-                                color=rating_color(row.rating),
-                            ),
-                        ],
-                    ),
+                    self._score_badge(row.normalized_score, row.rating),
                 ],
             ),
         )
 
-    def expanded_body(card: RankedLocationView) -> list[Any]:
-        color = rating_color(card.rating)
-        if card.is_ranked:
-            recommendation = [
-                ft.Row(
-                    spacing=4,
-                    controls=[
-                        ft.Icon(ft.Icons.ACCESS_TIME, size=18, color=TEXT_COLOR),
-                        ft.Text(card.best_window, size=16, weight=ft.FontWeight.BOLD, color=TEXT_COLOR),
-                    ],
-                ),
-                ft.Text(card.best_window_details, size=13, color=TEXT_SECONDARY_COLOR),
-            ]
-        else:
-            recommendation = [
-                ft.Text(card.best_window_details, size=13, color=TEXT_SECONDARY_COLOR),
-            ]
+    # --- Legend and footer ------------------------------------------------
 
-        rows = model.hourly_forecast(card.location_key)
-        hourly_controls = (
-            [hourly_row(row) for row in rows]
-            if rows
-            else [ft.Text("No hourly forecast is available.", color=TEXT_SECONDARY_COLOR)]
-        )
-
-        return [
+    def _build_legend(self) -> Any:
+        ft = self.ft
+        chips = [
             ft.Container(
-                padding=ft.Padding(left=16, top=8, right=16, bottom=12),
-                content=ft.Column(
-                    spacing=6,
-                    controls=[
-                        ft.Divider(height=1, color=color),
-                        *recommendation,
-                        ft.Container(height=4),
-                        *hourly_controls,
-                    ],
-                ),
-            ),
-        ]
-
-    def location_tile(
-        card: RankedLocationView,
-        *,
-        leading: Any,
-        badge_text: str,
-        is_selected: bool,
-    ) -> Any:
-        color = rating_color(card.rating)
-        bg = rating_background(card.rating)
-        summary_bits = card.rating if card.is_ranked else "Not ranked"
-        subtitle = f"{summary_bits} · {card.weather_description}"
-
-        def on_tile_change(event: Any) -> None:
-            if event.data:
-                choose_location(card.location_key)
-
-        tile = ft.ExpansionTile(
-            key=f"tile_{card.location_key}",
-            title=ft.Text(card.location_name, size=16, weight=ft.FontWeight.BOLD, color=TEXT_COLOR),
-            subtitle=ft.Text(subtitle, size=12, color=TEXT_SECONDARY_COLOR, no_wrap=True),
-            leading=leading,
-            trailing=ft.Text(badge_text, size=14, weight=ft.FontWeight.BOLD, color=color),
-            expanded=is_selected,
-            tile_padding=ft.Padding(left=12, top=6, right=12, bottom=6),
-            collapsed_bgcolor=ft.Colors.TRANSPARENT,
-            bgcolor=ft.Colors.TRANSPARENT,
-            icon_color=color,
-            collapsed_icon_color=TEXT_SECONDARY_COLOR,
-            on_change=on_tile_change,
-            controls=expanded_body(card),
-        )
-        return ft.Container(
-            key=f"card_{card.location_key}",
-            bgcolor=bg,
-            border=ft.Border.all(1.5 if is_selected else 1, color if is_selected else BORDER_COLOR),
-            border_radius=14,
-            clip_behavior=ft.ClipBehavior.ANTI_ALIAS,
-            content=tile,
-        )
-
-    def rank_badge(rank: int, color: str) -> Any:
-        return ft.CircleAvatar(
-            content=ft.Text(f"{rank}", size=13, weight=ft.FontWeight.BOLD, color=ft.Colors.WHITE),
-            bgcolor=color,
-            radius=15,
-        )
-
-    def choose_location(location_key: str) -> None:
-        model.select_location(location_key)
-        location_dropdown.value = location_key
-        render_forecast_list()
-        update_filters_summary()
-        page.update()
-        page.run_task(page.scroll_to, scroll_key=f"card_{location_key}", duration=300)
-
-    # --- Daily summary ---
-
-    def summary_table_row(summary: Any) -> ft.Row:
-        return ft.Row(
-            spacing=6,
-            vertical_alignment=ft.CrossAxisAlignment.CENTER,
-            controls=[
-                ft.Icon(
-                    getattr(ft.Icons, _get_activity_icon_name(summary.activity_profile)),
-                    size=14,
-                    color=TEXT_SECONDARY_COLOR,
-                ),
-                ft.Text(
-                    summary.location_name,
-                    width=96,
-                    size=12,
-                    color=TEXT_COLOR,
-                    no_wrap=True,
-                ),
-                ft.Text(
-                    summary.score_text,
-                    width=58,
-                    size=12,
+                padding=ft.Padding(left=8, top=3, right=8, bottom=3),
+                bgcolor=self.palette.rating_background(rating),
+                border_radius=6,
+                content=self._text(
+                    rating,
+                    size=LABEL_SIZE,
+                    color=self.palette.rating(rating),
                     weight=ft.FontWeight.BOLD,
-                    text_align=ft.TextAlign.RIGHT,
-                    color=PRIMARY_COLOR,
-                    no_wrap=True,
                 ),
-                ft.Text(
-                    summary.best_window,
-                    expand=True,
-                    size=12,
-                    color=TEXT_SECONDARY_COLOR,
-                    no_wrap=True,
-                ),
-            ],
-        )
-
-    def render_daily_summary() -> None:
-        rows = model.daily_summary_rows()
-        if not rows:
-            daily_summary.controls = [
-                ft.Text(
-                    "No daily activity recommendations are available.",
-                    size=13,
-                    color=TEXT_SECONDARY_COLOR,
-                )
-            ]
-            return
-
-        controls = [
-            ft.Row(
+            )
+            for rating in RATING_ORDER
+        ]
+        return self._card(
+            ft.Column(
                 spacing=6,
                 controls=[
-                    ft.Container(width=14),
-                    ft.Text("Location", width=96, size=11, color=TEXT_SECONDARY_COLOR),
-                    ft.Text("Score", width=58, size=11, color=TEXT_SECONDARY_COLOR),
-                    ft.Text("Best time", expand=True, size=11, color=TEXT_SECONDARY_COLOR),
+                    self._secondary(
+                        "Scores run 0-100 for the selected activity: higher is better."
+                    ),
+                    ft.Row(spacing=6, wrap=True, run_spacing=6, controls=chips),
                 ],
+            ),
+            padding=SPACING,
+        )
+
+    def _build_footer(self) -> Any:
+        return self.ft.Markdown(
+            f"Data from [MET Norway]({MET_NORWAY_SOURCE_URL}), "
+            f"processed by Weather Helper · "
+            f"[license]({MET_NORWAY_LICENSE_URL})",
+            selectable=True,
+        )
+
+    # --- Rendering --------------------------------------------------------
+
+    def render_dashboard(self) -> None:
+        """Redraw every part of the screen from the current model state."""
+        self._update_date_options()
+        self.render_headline()
+        self.render_pinned()
+        self.render_forecast_list()
+        self.freshness.value = self.model.freshness_label()
+        self.page.update()
+
+    def _selected_day_label(self) -> str:
+        if self.model.selected_date is None:
+            return "today"
+        return format_relative_date(self.model.selected_date, get_current_date())
+
+    def _update_date_options(self) -> None:
+        ft = self.ft
+        today = get_current_date()
+        available_dates = self.model.available_dates()
+        self.date_dropdown.options = [
+            ft.DropdownOption(
+                key=value.isoformat(), text=format_relative_date(value, today)
             )
-        ]
-        alternatives_started = False
-        for summary in rows:
-            if not summary.is_priority and not alternatives_started:
-                controls.append(ft.Divider(height=8))
-                controls.append(
-                    ft.Text(
-                        "Alternatives",
-                        size=12,
-                        weight=ft.FontWeight.BOLD,
-                        color=TEXT_SECONDARY_COLOR,
-                    )
-                )
-                alternatives_started = True
-            controls.append(summary_table_row(summary))
-        daily_summary.controls = controls
-
-    # --- Merged ranking + details list ---
-
-    def render_forecast_list() -> None:
-        ranked = model.ranked_locations()
-        selected = model.selected_location()
-        ranked_keys = {card.location_key for card in ranked}
-
-        tiles = []
-        if selected is not None and selected.location_key not in ranked_keys:
-            tiles.append(
-                location_tile(
-                    selected,
-                    leading=ft.Icon(ft.Icons.INFO_OUTLINE, color=TEXT_SECONDARY_COLOR),
-                    badge_text="N/A",
-                    is_selected=True,
-                )
-            )
-        for rank, card in enumerate(ranked, 1):
-            tiles.append(
-                location_tile(
-                    card,
-                    leading=rank_badge(rank, rating_color(card.rating)),
-                    badge_text=f"{card.normalized_score}",
-                    is_selected=card.location_key == model.selected_location_key,
-                )
-            )
-
-        forecast_list.controls = tiles or [
-            ft.Text(
-                "No location is available for this date.",
-                color=TEXT_SECONDARY_COLOR,
-            )
-        ]
-
-    def update_location_options() -> None:
-        options = model.location_options()
-        location_dropdown.options = [
-            ft.DropdownOption(key=key, text=name) for key, name in options
-        ]
-        location_dropdown.disabled = not options
-        location_dropdown.hint_text = "Choose a location"
-        location_dropdown.value = model.selected_location_key or None
-
-    def update_filters_summary() -> None:
-        selected = model.selected_location()
-        location_bit = selected.location_name if selected else "no location"
-        date_bit = model.selected_date.strftime("%a, %d %b") if model.selected_date else "no date"
-        profile_bit = ACTIVITY_PROFILE_LABELS.get(model.activity_profile, model.activity_profile)
-        filters_summary.value = f"{model.group_name} · {location_bit} · {date_bit} · {profile_bit}"
-
-    def render_dashboard() -> None:
-        update_location_options()
-        update_filters_summary()
-        render_daily_summary()
-        render_forecast_list()
-        page.update()
-
-    def update_date_options() -> None:
-        available_dates = model.available_dates()
-        date_dropdown.options = [
-            ft.DropdownOption(key=value.isoformat(), text=f"{value:%a, %d/%m}")
             for value in available_dates
         ]
-        date_dropdown.disabled = not available_dates
-        date_dropdown.value = model.selected_date.isoformat() if model.selected_date else None
+        self.date_dropdown.disabled = not available_dates
+        self.date_dropdown.value = (
+            self.model.selected_date.isoformat() if self.model.selected_date else None
+        )
 
-    def on_group_select(event: Any) -> None:
-        model.select_group(event.control.value)
-        update_date_options()
-        location_dropdown.options = []
-        location_dropdown.value = None
-        location_dropdown.disabled = True
-        forecast_list.controls = []
-        daily_summary.controls = []
-        status.value = f"Loading {model.group_name} forecasts…"
-        page.update()
-        page.run_task(refresh_forecast)
+    # --- Events -----------------------------------------------------------
 
-    def on_location_select(event: Any) -> None:
-        choose_location(event.control.value)
+    def _guard(self, action: Callable[[], None]) -> None:
+        """Run a handler, turning an unexpected failure into a visible message.
 
-    def on_profile_select(event: Any) -> None:
-        model.select_activity_profile(event.control.value)
-        render_dashboard()
+        An exception inside a Flet event handler is otherwise silent, which
+        would leave the screen looking as though the tap did nothing.
+        """
+        try:
+            action()
+        except Exception:
+            self.status.value = "That selection is no longer available. Refreshing…"
+            self.page.update()
+            self.page.run_task(self.refresh_forecast)
 
-    def on_date_select(event: Any) -> None:
-        model.select_date(date.fromisoformat(event.control.value))
-        render_dashboard()
+    def on_tile_toggle(self, location_key: str, expanded: bool) -> None:
+        def apply() -> None:
+            if expanded:
+                self._expanded_keys = {location_key}
+                self.model.select_location(location_key)
+            else:
+                self._expanded_keys.discard(location_key)
+            self.render_forecast_list()
+            self.page.update()
+            if expanded:
+                self.page.run_task(self._scroll_to_card, location_key)
 
-    async def refresh_forecast(event: Any = None) -> None:
-        refresh_button.disabled = True
-        group_dropdown.disabled = True
-        progress.visible = True
-        status.value = f"Loading {model.group_name} forecasts…"
-        page.update()
+        self._guard(apply)
+
+    async def _scroll_to_card(self, location_key: str) -> None:
+        """Bring a newly opened card into view inside the scrolling list."""
+        await self.list_view.scroll_to(
+            scroll_key=self.ft.ScrollKey(f"card_{location_key}"), duration=300
+        )
+
+    def on_group_select(self, event: Any) -> None:
+        def apply() -> None:
+            self.model.select_group(event.control.value)
+            self.forecast_list.controls = []
+            self._expanded_keys.clear()
+            self.page.update()
+            self.page.run_task(self.refresh_forecast)
+
+        self._guard(apply)
+
+    def on_profile_select(self, event: Any) -> None:
+        def apply() -> None:
+            self.model.select_activity_profile(event.control.value)
+            self.render_dashboard()
+
+        self._guard(apply)
+
+    def on_date_select(self, event: Any) -> None:
+        def apply() -> None:
+            self.model.select_date(date.fromisoformat(event.control.value))
+            self._expanded_keys.clear()
+            self.render_dashboard()
+
+        self._guard(apply)
+
+    def on_refresh_click(self, event: Any) -> None:
+        self.page.run_task(self.refresh_forecast)
+
+    def on_brightness_change(self, event: Any) -> None:
+        """Follow the device between light and dark mode."""
+        self.palette = Palette(dark=self._prefers_dark())
+        self.build(initial_load=False)
+        self.render_dashboard()
+
+    def on_lifecycle_change(self, event: Any) -> None:
+        """Refresh stale data when the app comes back to the foreground."""
+        if event.data == self.ft.AppLifecycleState.RESUME and self.model.is_stale():
+            self.page.run_task(self.refresh_forecast)
+
+    # --- Loading ----------------------------------------------------------
+
+    async def refresh_forecast(self, event: Any = None) -> None:
+        """Reload the selected region, ignoring results from a superseded load."""
+        self._load_generation += 1
+        generation = self._load_generation
+        self._set_loading(True)
+        self.status.value = f"Loading {self.model.group_name}…"
+        self.page.update()
+
+        def report_progress(current: int, total: int, location: Any) -> None:
+            if generation == self._load_generation:
+                self.status.value = f"Loading {self.model.group_name}… {current}/{total}"
 
         try:
-            batch = await asyncio.to_thread(model.load)
-            update_date_options()
-            if batch.loaded_count:
-                status.value = f"Loaded {batch.loaded_count} locations"
-                if batch.errors:
-                    status.value += f" · {len(batch.errors)} unavailable"
-            else:
-                status.value = (
-                    "No forecasts could be loaded. Check your connection and try again."
-                )
-            render_dashboard()
+            self.model.invalidate_rankings()
+            batch = await asyncio.to_thread(self.model.load, report_progress)
         except Exception:
-            status.value = "Unable to load forecasts right now. Please try again."
-            forecast_list.controls = []
-            daily_summary.controls = []
-        finally:
-            progress.visible = False
-            refresh_button.disabled = False
-            group_dropdown.disabled = False
-            page.update()
+            if generation == self._load_generation:
+                self.status.value = (
+                    "Could not load forecasts. Check your connection and try again."
+                )
+                self._set_loading(False)
+                self.page.update()
+            return
 
-    group_dropdown.on_select = on_group_select
-    location_dropdown.on_select = on_location_select
-    profile_dropdown.on_select = on_profile_select
-    date_dropdown.on_select = on_date_select
-    refresh_button.on_click = refresh_forecast
+        if generation != self._load_generation:
+            return  # A newer load is already in flight; its result wins.
 
-    # --- App bar ---
-    page.appbar = ft.AppBar(
-        title=ft.Text("Weather Helper", weight=ft.FontWeight.BOLD),
-        center_title=False,
-        bgcolor=PRIMARY_COLOR,
-        color=ft.Colors.WHITE,
-        actions=[refresh_button],
-    )
+        self.status.value = _load_summary(batch, self.model.group_name)
+        self._set_loading(False)
+        self.render_dashboard()
 
-    # --- Status row (always visible loading feedback) ---
-    status_row = ft.Column(
-        spacing=4,
-        controls=[status, progress],
-    )
+    def _set_loading(self, loading: bool) -> None:
+        self.progress.visible = loading
+        self.refresh_button.disabled = loading
+        self.group_dropdown.disabled = loading
 
-    # --- Collapsible filters ---
-    filters_summary = ft.Text(
-        f"{model.group_name} · Loading…",
-        size=12,
-        color=TEXT_SECONDARY_COLOR,
-        no_wrap=True,
-    )
-    filters_tile = ft.ExpansionTile(
-        title=ft.Text("Filters", size=15, weight=ft.FontWeight.BOLD, color=TEXT_COLOR),
-        subtitle=filters_summary,
-        leading=ft.Icon(ft.Icons.TUNE, color=PRIMARY_COLOR),
-        tile_padding=ft.Padding(left=14, top=4, right=14, bottom=4),
-        collapsed_bgcolor=ft.Colors.TRANSPARENT,
-        bgcolor=ft.Colors.TRANSPARENT,
-        controls=[
-            ft.Container(
-                padding=ft.Padding(left=14, top=0, right=14, bottom=14),
-                content=ft.ResponsiveRow(
-                    columns=12,
-                    spacing=8,
-                    run_spacing=8,
-                    controls=[
-                        ft.Container(col={"xs": 12, "sm": 6}, content=group_dropdown),
-                        ft.Container(col={"xs": 12, "sm": 6}, content=location_dropdown),
-                        ft.Container(col={"xs": 12, "sm": 6}, content=date_dropdown),
-                        ft.Container(col={"xs": 12, "sm": 6}, content=profile_dropdown),
-                    ],
-                ),
-            ),
-        ],
-    )
-    filters_card = ft.Container(
-        bgcolor=SURFACE_COLOR,
-        border=ft.Border.all(1, BORDER_COLOR),
-        border_radius=14,
-        clip_behavior=ft.ClipBehavior.ANTI_ALIAS,
-        content=filters_tile,
-    )
+    # --- Assembly ---------------------------------------------------------
 
-    daily_summary_panel = elevated_card(
-        ft.Column(
-            spacing=6,
+    def build(self, initial_load: bool = True) -> None:
+        ft = self.ft
+        self._apply_theme()
+        self.page.title = "Weather Helper"
+        self.page.padding = 0
+        self._build_header()
+
+        self.list_view = ft.ListView(
+            expand=True,
+            spacing=SPACING,
+            padding=SPACING,
             controls=[
-                ft.Row(
-                    spacing=6,
-                    controls=[
-                        ft.Icon(ft.Icons.WB_SUNNY_OUTLINED, size=18, color=PRIMARY_COLOR),
-                        ft.Text("Today's best windows", size=16, weight=ft.FontWeight.BOLD, color=TEXT_COLOR),
-                    ],
-                ),
-                ft.Text(
-                    "Oviedo and Gijón are shown first for hiking and beach plans.",
-                    size=12,
-                    color=TEXT_SECONDARY_COLOR,
-                ),
-                daily_summary,
+                self._build_status(),
+                self._build_filters(),
+                self._build_headline(),
+                self._build_pinned(),
+                self._build_ranking(),
+                self._build_legend(),
+                self._build_footer(),
             ],
         )
-    )
+        self.page.controls = []
+        self.page.add(ft.SafeArea(expand=True, content=self.list_view))
+        self.page.on_platform_brightness_change = self.on_brightness_change
+        self.page.on_app_lifecycle_state_change = self.on_lifecycle_change
 
-    ranking_header = ft.Row(
-        spacing=6,
-        controls=[
-            ft.Icon(ft.Icons.LEADERBOARD, size=18, color=PRIMARY_COLOR),
-            ft.Text("Ranked locations", size=16, weight=ft.FontWeight.BOLD, color=TEXT_COLOR),
-        ],
-    )
-    ranking_hint = ft.Text(
-        "Tap a location for its full hourly breakdown.",
-        size=12,
-        color=TEXT_SECONDARY_COLOR,
-    )
+        if initial_load:
+            self.page.run_task(self.refresh_forecast)
 
-    page.add(
-        ft.SafeArea(
-            expand=True,
-            content=ft.ListView(
-                expand=True,
-                spacing=12,
-                padding=12,
-                controls=[
-                    status_row,
-                    filters_card,
-                    daily_summary_panel,
-                    ranking_header,
-                    ranking_hint,
-                    forecast_list,
-                    ft.Markdown(
-                        f"Data from [MET Norway]({MET_NORWAY_SOURCE_URL}), "
-                        f"processed by Weather Helper · "
-                        f"[license]({MET_NORWAY_LICENSE_URL})",
-                        selectable=True,
-                    ),
-                ],
-            ),
-        )
-    )
-    page.run_task(refresh_forecast)
+
+def _rating_for_rank_marker(rank: int) -> str:
+    """Return a rating whose tint suits a rank position."""
+    if rank == 1:
+        return "Excellent"
+    if rank <= 3:
+        return "Very Good"
+    return "Good"
+
+
+def _load_summary(batch: Any, group_name: str) -> str:
+    """Describe the outcome of a load, naming anything that failed."""
+    if not batch.loaded_count:
+        return f"No {group_name} forecasts could be loaded. Check your connection."
+    summary = f"{batch.loaded_count} locations loaded"
+    if batch.failure_summary:
+        summary += f" · unavailable: {batch.failure_summary}"
+    return summary
 
 
 def main() -> None:

--- a/src/mobile/daily_summary.py
+++ b/src/mobile/daily_summary.py
@@ -1,7 +1,8 @@
 """Daily activity summaries shared by the mobile screen and notifications."""
 
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date
+from types import MappingProxyType
 from typing import Mapping, Optional, Sequence
 
 from src.core.evaluation import get_top_locations_for_date
@@ -38,27 +39,46 @@ class DailySummaryRow:
         return f"{self.normalized_score}/100"
 
 
+def resolve_priority_keys(
+    locations: Mapping[str, Location],
+    forecasts: Mapping[str, dict] = MappingProxyType({}),
+    priority_location_keys: Sequence[str] = PRIORITY_LOCATION_KEYS,
+) -> list[str]:
+    """Return the priority locations that exist in the current region.
+
+    Regions outside Asturias contain neither Oviedo nor Gijon, so nothing is
+    pinned there and the screen must not claim otherwise.
+    """
+    return [
+        key
+        for key in priority_location_keys
+        if key in locations and (not forecasts or key in forecasts)
+    ]
+
+
 def build_daily_summary(
     forecasts: Mapping[str, dict],
     forecast_date: date,
     locations: Mapping[str, Location],
     *,
+    activity_profiles: Sequence[str] = SUMMARY_ACTIVITY_PROFILES,
     priority_location_keys: Sequence[str] = PRIORITY_LOCATION_KEYS,
     alternative_limit: int = DEFAULT_ALTERNATIVE_LIMIT,
 ) -> list[DailySummaryRow]:
     """Build priority rows first, followed by the strongest alternatives.
 
-    Oviedo and Gijon remain visible even when their conditions do not qualify
-    for the normal location ranking. Alternatives are limited per activity so
-    the result remains useful in a notification.
+    Pinned locations stay visible even when their conditions do not qualify for
+    the normal ranking, which is the point of the panel: it answers "how is it
+    at home, and where is better today" in one look. Alternatives are limited
+    per activity so the result stays readable.
     """
     primary_rows: list[DailySummaryRow] = []
     alternative_rows: list[DailySummaryRow] = []
-    priority_keys = {
-        key for key in priority_location_keys if key in locations and key in forecasts
-    }
+    priority_keys = set(
+        resolve_priority_keys(locations, forecasts, priority_location_keys)
+    )
 
-    for activity_profile in SUMMARY_ACTIVITY_PROFILES:
+    for activity_profile in activity_profiles:
         ranked = get_top_locations_for_date(
             dict(forecasts),
             forecast_date,

--- a/src/mobile/daily_summary.py
+++ b/src/mobile/daily_summary.py
@@ -168,7 +168,7 @@ def _row_from_result(
         )
 
     block = result["optimal_block"]
-    end_time = block["end"] + timedelta(hours=1)
+    end_time = block["end_time"]
     raw_score = float(result["raw_score"])
     return DailySummaryRow(
         activity_profile=activity_profile,

--- a/src/mobile/theme.py
+++ b/src/mobile/theme.py
@@ -1,0 +1,68 @@
+"""Colour and type scale for the mobile screen.
+
+Keeping these in one place is what stops the screen drifting into a dozen
+slightly different greys and font sizes, and it makes the dark palette a
+single switch rather than a per-widget decision.
+"""
+
+from dataclasses import dataclass
+
+from src.application.presentation import (
+    get_palette,
+    get_rating_background,
+    get_rating_color,
+)
+
+# Type scale. Nothing carrying data is allowed below BODY, so the screen stays
+# readable at arm's length on a phone.
+TITLE_SIZE = 20
+HEADLINE_SIZE = 28
+SUBTITLE_SIZE = 17
+BODY_SIZE = 15
+LABEL_SIZE = 13
+
+SPACING = 12
+CARD_RADIUS = 16
+MIN_TOUCH_TARGET = 48
+
+
+@dataclass(frozen=True)
+class Palette:
+    """Resolved colours for one brightness."""
+
+    dark: bool
+
+    def __getitem__(self, key: str) -> str:
+        return get_palette(self.dark)[key]
+
+    @property
+    def background(self) -> str:
+        return self["background"]
+
+    @property
+    def surface(self) -> str:
+        return self["surface"]
+
+    @property
+    def text(self) -> str:
+        return self["text"]
+
+    @property
+    def text_secondary(self) -> str:
+        return self["text_secondary"]
+
+    @property
+    def primary(self) -> str:
+        return self["primary"]
+
+    @property
+    def border(self) -> str:
+        return self["border"]
+
+    def rating(self, rating: str) -> str:
+        """Return the foreground colour for a rating."""
+        return get_rating_color(rating, self.dark)
+
+    def rating_background(self, rating: str) -> str:
+        """Return the surface tint for a rating."""
+        return get_rating_background(rating, self.dark)

--- a/src/mobile/view_model.py
+++ b/src/mobile/view_model.py
@@ -33,6 +33,7 @@ from src.mobile.daily_summary import (
     DailySummaryRow,
     build_daily_summary,
     format_daily_summary,
+    resolve_priority_keys,
 )
 
 DEFAULT_LOCATION_GROUP = "Asturias"
@@ -276,14 +277,26 @@ class MobileWeatherViewModel:
         self.selected_location_key = available[0] if available else ""
 
     def daily_summary_rows(self) -> list[DailySummaryRow]:
-        """Return both activities with priority cities before alternatives."""
+        """Return the pinned locations and best alternatives for the activity.
+
+        The summary follows the selected activity, so it can never recommend a
+        beach window while the rest of the screen is ranked for hiking.
+        """
         if self.selected_date is None:
             return []
         return build_daily_summary(
             self.forecasts,
             self.selected_date,
             self.locations,
+            activity_profiles=(self.activity_profile,),
         )
+
+    def priority_location_names(self) -> list[str]:
+        """Return the names of the locations pinned in the current region."""
+        return [
+            self.locations[key].name
+            for key in resolve_priority_keys(self.locations, self.forecasts)
+        ]
 
     def daily_summary_text(self) -> str:
         """Return the aligned summary text used by a notification or preview."""

--- a/src/mobile/view_model.py
+++ b/src/mobile/view_model.py
@@ -58,6 +58,8 @@ class RankedLocationView:
     best_window: str
     best_window_details: str
     window_hours: int = 0
+    window_score: Optional[int] = None
+    window_rating: str = "N/A"
 
     @property
     def is_ranked(self) -> bool:
@@ -366,6 +368,12 @@ class MobileWeatherViewModel:
             best_window=best_window,
             best_window_details=_format_best_window_details(block),
             window_hours=block.get("duration_hours", block.get("duration", 0)),
+            window_score=normalize_score(
+                item["window_score"], self.activity_profile
+            ),
+            window_rating=get_rating_info(
+                item["window_score"], self.activity_profile
+            ),
         )
 
     def _unranked_location_view(self, location_key: str) -> RankedLocationView:

--- a/src/mobile/view_model.py
+++ b/src/mobile/view_model.py
@@ -10,6 +10,7 @@ from src.application.forecast_service import (
     ProgressCallback,
 )
 from src.application.presentation import (
+    format_duration,
     format_percentage,
     format_precipitation,
     format_temperature,
@@ -69,9 +70,7 @@ class RankedLocationView:
     @property
     def window_length_label(self) -> str:
         """Return how long the recommended window lasts."""
-        if not self.window_hours:
-            return ""
-        return "1 hour" if self.window_hours == 1 else f"{self.window_hours} hours"
+        return format_duration(self.window_hours) if self.window_hours else ""
 
 
 @dataclass(frozen=True)
@@ -93,6 +92,15 @@ class HourlyForecastView:
     def is_hourly(self) -> bool:
         """Return True when this row describes a single hour."""
         return self.coverage_hours == 1
+
+    @property
+    def precipitation_unit(self) -> str:
+        """Return the unit the precipitation figure is expressed in.
+
+        Multi-hour entries report a rate, which is what they are scored on, so
+        the number on screen and the rating beside it always agree.
+        """
+        return " mm" if self.is_hourly else " mm/h"
 
     @property
     def span_label(self) -> str:
@@ -133,24 +141,25 @@ class MobileWeatherViewModel:
         if self.selected_location_key not in self.available_location_keys():
             self._select_default_location()
 
-    def _ranked_results(self, top_n: int) -> list[dict]:
+    def _ranked_results(self, top_n: Optional[int] = None) -> list[dict]:
         """Return ranked results for the current selection, computed once.
 
-        Ranking scans every location's forecast, and a single screen refresh
-        asks for it several times. Caching per selection keeps changing a
-        filter responsive on a phone.
+        Ranking scans every location's forecast, which is the most expensive
+        thing a redraw does. The full ordering is computed once per selection
+        and sliced, so a screen refresh cannot rank the same region repeatedly.
         """
         if self.selected_date is None:
             return []
-        cache_key = (self.selected_date, self.activity_profile, top_n)
+        cache_key = (self.selected_date, self.activity_profile)
         if cache_key not in self._ranking_cache:
             self._ranking_cache[cache_key] = get_top_locations_for_date(
                 self.forecasts,
                 self.selected_date,
-                top_n=top_n,
+                top_n=max(1, len(self.forecasts)),
                 activity_profile=self.activity_profile,
             )
-        return self._ranking_cache[cache_key]
+        ranked = self._ranking_cache[cache_key]
+        return ranked if top_n is None else ranked[:top_n]
 
     def invalidate_rankings(self) -> None:
         """Drop cached rankings so time-sensitive results are recomputed."""
@@ -224,9 +233,7 @@ class MobileWeatherViewModel:
         ranked = next(
             (
                 self._ranked_location_view(index, item)
-                for index, item in enumerate(
-                    self._ranked_results(max(1, len(self.forecasts))), 1
-                )
+                for index, item in enumerate(self._ranked_results(), 1)
                 if item["location_key"] == self.selected_location_key
             ),
             None,
@@ -258,12 +265,6 @@ class MobileWeatherViewModel:
         window = self._best_window_bounds(location_key)
         return [self._hourly_forecast_view(hour, window) for hour in hours]
 
-    def selected_hourly_forecast(self) -> list[HourlyForecastView]:
-        """Return the breakdown for the currently selected location."""
-        if not self.selected_location_key:
-            return []
-        return self.hourly_forecast(self.selected_location_key)
-
     def _best_window_bounds(
         self, location_key: str
     ) -> Optional[tuple[datetime, datetime]]:
@@ -271,7 +272,7 @@ class MobileWeatherViewModel:
         ranked = next(
             (
                 item
-                for item in self._ranked_results(len(self.forecasts))
+                for item in self._ranked_results()
                 if item["location_key"] == location_key
             ),
             None,
@@ -412,14 +413,12 @@ class MobileWeatherViewModel:
             temperature=hour.temp,
             wind=hour.wind,
             clouds=hour.cloud_coverage,
-            precipitation=hour.precipitation_amount,
+            # The rate is shown, because the rate is what was scored.
+            precipitation=hour.precipitation_rate,
             humidity=hour.relative_humidity,
             normalized_score=normalize_score(raw_score, self.activity_profile),
             rating=get_rating_info(raw_score, self.activity_profile),
-            coverage_hours=int(
-                round((visible_end - visible_start).total_seconds() / 3600)
-            )
-            or 1,
+            coverage_hours=hour.coverage_hours,
             in_best_window=_is_inside_window(hour, window),
         )
 

--- a/src/mobile/view_model.py
+++ b/src/mobile/view_model.py
@@ -1,7 +1,7 @@
 """Pure presentation state for the Flet Weather Helper screen."""
 
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Optional
 
 from src.application.forecast_service import (
@@ -16,6 +16,7 @@ from src.application.presentation import (
     format_wind_speed,
 )
 from src.core.evaluation import (
+    daylight_bounds,
     get_available_dates,
     get_recommendation_hours,
     get_time_blocks_for_date,
@@ -37,6 +38,10 @@ from src.mobile.daily_summary import (
 )
 
 DEFAULT_LOCATION_GROUP = "Asturias"
+
+# Forecasts older than this are flagged, so a screen opened the next morning
+# never presents yesterday's plan as if it were current.
+STALE_AFTER = timedelta(hours=1)
 
 
 @dataclass(frozen=True)
@@ -251,6 +256,12 @@ class MobileWeatherViewModel:
         window = self._best_window_bounds(location_key)
         return [self._hourly_forecast_view(hour, window) for hour in hours]
 
+    def selected_hourly_forecast(self) -> list[HourlyForecastView]:
+        """Return the breakdown for the currently selected location."""
+        if not self.selected_location_key:
+            return []
+        return self.hourly_forecast(self.selected_location_key)
+
     def _best_window_bounds(
         self, location_key: str
     ) -> Optional[tuple[datetime, datetime]]:
@@ -289,6 +300,33 @@ class MobileWeatherViewModel:
             self.selected_date,
             self.locations,
             activity_profiles=(self.activity_profile,),
+        )
+
+    def top_recommendation(self) -> Optional[RankedLocationView]:
+        """Return the single best place to be, which is the app's whole point."""
+        ranked = self.ranked_locations(1)
+        return ranked[0] if ranked else None
+
+    def is_stale(self, max_age: timedelta = STALE_AFTER) -> bool:
+        """Return True when the loaded data is too old to trust for today."""
+        if self.loaded_at is None:
+            return True
+        if datetime.now().date() != self.loaded_at.date():
+            return True
+        return datetime.now() - self.loaded_at > max_age
+
+    def freshness_label(self) -> str:
+        """Return a short description of how current the data is."""
+        if self.loaded_at is None:
+            return "Not loaded yet"
+        if self.is_stale():
+            return f"Updated {self.loaded_at:%H:%M} · may be out of date"
+        return f"Updated {self.loaded_at:%H:%M}"
+
+    def activity_label(self) -> str:
+        """Return the display label for the selected activity."""
+        return ACTIVITY_PROFILE_LABELS.get(
+            self.activity_profile, self.activity_profile
         )
 
     def priority_location_names(self) -> list[str]:
@@ -358,9 +396,11 @@ class MobileWeatherViewModel:
         self, hour, window: Optional[tuple[datetime, datetime]]
     ) -> HourlyForecastView:
         raw_score = get_activity_score(hour, self.activity_profile)
+        visible_start, visible_end = daylight_bounds(hour)
         return HourlyForecastView(
-            time=format_window(hour.time, hour.end_time) if not hour.is_hourly
-            else f"{hour.time:%H:%M}",
+            time=f"{hour.time:%H:%M}"
+            if hour.is_hourly
+            else format_window(visible_start, visible_end),
             temperature=hour.temp,
             wind=hour.wind,
             clouds=hour.cloud_coverage,
@@ -368,7 +408,10 @@ class MobileWeatherViewModel:
             humidity=hour.relative_humidity,
             normalized_score=normalize_score(raw_score, self.activity_profile),
             rating=get_rating_info(raw_score, self.activity_profile),
-            coverage_hours=hour.coverage_hours,
+            coverage_hours=int(
+                round((visible_end - visible_start).total_seconds() / 3600)
+            )
+            or 1,
             in_best_window=_is_inside_window(hour, window),
         )
 
@@ -379,11 +422,16 @@ def format_window(start: datetime, end: datetime) -> str:
 
 
 def _is_inside_window(hour, window: Optional[tuple[datetime, datetime]]) -> bool:
-    """Return True when an entry falls inside the recommended window."""
+    """Return True when an entry overlaps the recommended window.
+
+    The comparison uses the daylight part of the entry, so the first entry of a
+    window that began before dawn is still marked as part of it.
+    """
     if window is None:
         return False
-    start, end = window
-    return start <= hour.time < end
+    window_start, window_end = window
+    entry_start, entry_end = daylight_bounds(hour)
+    return entry_start < window_end and entry_end > window_start
 
 
 def _format_best_window_details(block: dict) -> str:

--- a/src/mobile/view_model.py
+++ b/src/mobile/view_model.py
@@ -229,7 +229,7 @@ class MobileWeatherViewModel:
     def _ranked_location_view(self, rank: int, item: dict) -> RankedLocationView:
         raw_score = float(item["raw_score"])
         block = item["optimal_block"]
-        end_time = block["end"] + timedelta(hours=1)
+        end_time = block["end_time"]
         best_window = f"{block['start']:%H:%M} - {end_time:%H:%M}"
         return RankedLocationView(
             rank=rank,

--- a/src/mobile/view_model.py
+++ b/src/mobile/view_model.py
@@ -1,10 +1,14 @@
 """Pure presentation state for the Flet Weather Helper screen."""
 
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date, datetime
 from typing import Optional
 
-from src.application.forecast_service import ForecastBatch, ForecastService
+from src.application.forecast_service import (
+    ForecastBatch,
+    ForecastService,
+    ProgressCallback,
+)
 from src.application.presentation import (
     format_percentage,
     format_precipitation,
@@ -13,6 +17,7 @@ from src.application.presentation import (
 )
 from src.core.evaluation import (
     get_available_dates,
+    get_recommendation_hours,
     get_time_blocks_for_date,
     get_top_locations_for_date,
 )
@@ -46,25 +51,45 @@ class RankedLocationView:
     weather_description: str
     best_window: str
     best_window_details: str
+    window_hours: int = 0
 
     @property
     def is_ranked(self) -> bool:
         """Return True when the location has a qualifying recommendation."""
         return self.rank is not None
 
+    @property
+    def window_length_label(self) -> str:
+        """Return how long the recommended window lasts."""
+        if not self.window_hours:
+            return ""
+        return "1 hour" if self.window_hours == 1 else f"{self.window_hours} hours"
+
 
 @dataclass(frozen=True)
 class HourlyForecastView:
-    """Mobile-friendly summary of one hourly forecast row."""
+    """Mobile-friendly summary of one forecast entry."""
 
     time: str
-    temperature: str
-    wind: str
-    clouds: str
-    precipitation: str
-    humidity: str
+    temperature: Optional[float]
+    wind: Optional[float]
+    clouds: Optional[float]
+    precipitation: Optional[float]
+    humidity: Optional[float]
     normalized_score: int
     rating: str
+    coverage_hours: int
+    in_best_window: bool
+
+    @property
+    def is_hourly(self) -> bool:
+        """Return True when this row describes a single hour."""
+        return self.coverage_hours == 1
+
+    @property
+    def span_label(self) -> str:
+        """Return a label stating the period a row covers."""
+        return "" if self.is_hourly else f"{self.coverage_hours}h block"
 
 
 class MobileWeatherViewModel:
@@ -78,6 +103,8 @@ class MobileWeatherViewModel:
         self.selected_location_key = ""
         self.forecasts: dict[str, dict] = {}
         self.errors: dict[str, str] = {}
+        self.loaded_at: Optional[datetime] = None
+        self._ranking_cache: dict[tuple, list[dict]] = {}
 
     @property
     def locations(self):
@@ -98,13 +125,38 @@ class MobileWeatherViewModel:
         if self.selected_location_key not in self.available_location_keys():
             self._select_default_location()
 
-    def load(self) -> ForecastBatch:
+    def _ranked_results(self, top_n: int) -> list[dict]:
+        """Return ranked results for the current selection, computed once.
+
+        Ranking scans every location's forecast, and a single screen refresh
+        asks for it several times. Caching per selection keeps changing a
+        filter responsive on a phone.
+        """
+        if self.selected_date is None:
+            return []
+        cache_key = (self.selected_date, self.activity_profile, top_n)
+        if cache_key not in self._ranking_cache:
+            self._ranking_cache[cache_key] = get_top_locations_for_date(
+                self.forecasts,
+                self.selected_date,
+                top_n=top_n,
+                activity_profile=self.activity_profile,
+            )
+        return self._ranking_cache[cache_key]
+
+    def invalidate_rankings(self) -> None:
+        """Drop cached rankings so time-sensitive results are recomputed."""
+        self._ranking_cache.clear()
+
+    def load(self, on_progress: Optional[ProgressCallback] = None) -> ForecastBatch:
         """Load the selected group while preserving valid user selections."""
         previous_date = self.selected_date
         previous_location_key = self.selected_location_key
-        batch = self.service.load_locations(self.locations)
+        batch = self.service.load_locations(self.locations, on_progress)
         self.forecasts = batch.forecasts
         self.errors = batch.errors
+        self.loaded_at = datetime.now()
+        self.invalidate_rankings()
         available_dates = self.available_dates()
         self.selected_date = (
             previous_date if previous_date in available_dates
@@ -163,9 +215,11 @@ class MobileWeatherViewModel:
             return None
         ranked = next(
             (
-                item
-                for item in self.ranked_locations(len(self.forecasts))
-                if item.location_key == self.selected_location_key
+                self._ranked_location_view(index, item)
+                for index, item in enumerate(
+                    self._ranked_results(max(1, len(self.forecasts))), 1
+                )
+                if item["location_key"] == self.selected_location_key
             ),
             None,
         )
@@ -176,24 +230,50 @@ class MobileWeatherViewModel:
         return self._unranked_location_view(self.selected_location_key)
 
     def ranked_locations(self, top_n: int = 10) -> list[RankedLocationView]:
-        if self.selected_date is None:
-            return []
-        ranked = get_top_locations_for_date(
-            self.forecasts,
-            self.selected_date,
-            top_n=top_n,
-            activity_profile=self.activity_profile,
-        )
         return [
             self._ranked_location_view(index, item)
-            for index, item in enumerate(ranked, 1)
+            for index, item in enumerate(self._ranked_results(top_n), 1)
         ]
 
     def hourly_forecast(self, location_key: str) -> list[HourlyForecastView]:
+        """Return the entries the recommendation for this location is based on.
+
+        These are exactly the hours the ranking considered, so the breakdown
+        can never show a glowing 03:00 that the recommendation ignored, nor
+        hours that have already passed.
+        """
         if self.selected_date is None or location_key not in self.forecasts:
             return []
-        hours = get_time_blocks_for_date(self.forecasts[location_key], self.selected_date)
-        return [self._hourly_forecast_view(hour) for hour in hours]
+        hours = get_recommendation_hours(
+            self.forecasts[location_key], self.selected_date
+        )
+        window = self._best_window_bounds(location_key)
+        return [self._hourly_forecast_view(hour, window) for hour in hours]
+
+    def _best_window_bounds(
+        self, location_key: str
+    ) -> Optional[tuple[datetime, datetime]]:
+        """Return the start and end of the recommended window, if any."""
+        ranked = next(
+            (
+                item
+                for item in self._ranked_results(len(self.forecasts))
+                if item["location_key"] == location_key
+            ),
+            None,
+        )
+        if ranked is None:
+            return None
+        block = ranked["optimal_block"]
+        return block["start"], block["end_time"]
+
+    def _select_default_location(self) -> None:
+        ranked = self._ranked_results(1)
+        if ranked:
+            self.selected_location_key = ranked[0]["location_key"]
+            return
+        available = self.available_location_keys()
+        self.selected_location_key = available[0] if available else ""
 
     def daily_summary_rows(self) -> list[DailySummaryRow]:
         """Return both activities with priority cities before alternatives."""
@@ -212,25 +292,18 @@ class MobileWeatherViewModel:
             forecast_date=self.selected_date,
         )
 
-    def _select_default_location(self) -> None:
-        ranked = self.ranked_locations(1)
-        if ranked:
-            self.selected_location_key = ranked[0].location_key
-            return
-        available = self.available_location_keys()
-        self.selected_location_key = available[0] if available else ""
-
     def _clear_forecasts(self) -> None:
         self.forecasts = {}
         self.errors = {}
         self.selected_date = None
         self.selected_location_key = ""
+        self.loaded_at = None
+        self.invalidate_rankings()
 
     def _ranked_location_view(self, rank: int, item: dict) -> RankedLocationView:
         raw_score = float(item["raw_score"])
         block = item["optimal_block"]
-        end_time = block["end_time"]
-        best_window = f"{block['start']:%H:%M} - {end_time:%H:%M}"
+        best_window = format_window(block["start"], block["end_time"])
         return RankedLocationView(
             rank=rank,
             location_key=item["location_key"],
@@ -241,6 +314,7 @@ class MobileWeatherViewModel:
             weather_description=item["weather_desc"],
             best_window=best_window,
             best_window_details=_format_best_window_details(block),
+            window_hours=block.get("duration_hours", block.get("duration", 0)),
         )
 
     def _unranked_location_view(self, location_key: str) -> RankedLocationView:
@@ -261,24 +335,42 @@ class MobileWeatherViewModel:
             weather_description=description,
             best_window="",
             best_window_details=(
-                "No qualifying recommended window for this activity. "
-                "Review the hourly conditions below."
+                "No window here is good enough to recommend for this activity. "
+                "The hours below are what was considered."
             ),
+            window_hours=0,
         )
 
-    def _hourly_forecast_view(self, hour) -> HourlyForecastView:
+    def _hourly_forecast_view(
+        self, hour, window: Optional[tuple[datetime, datetime]]
+    ) -> HourlyForecastView:
         raw_score = get_activity_score(hour, self.activity_profile)
-        normalized = normalize_score(raw_score, self.activity_profile)
         return HourlyForecastView(
-            time=f"{hour.time:%H:%M}",
-            temperature=format_temperature(hour.temp),
-            wind=format_wind_speed(hour.wind),
-            clouds=format_percentage(hour.cloud_coverage),
-            precipitation=format_precipitation(hour.precipitation_amount),
-            humidity=format_percentage(hour.relative_humidity),
-            normalized_score=normalized,
+            time=format_window(hour.time, hour.end_time) if not hour.is_hourly
+            else f"{hour.time:%H:%M}",
+            temperature=hour.temp,
+            wind=hour.wind,
+            clouds=hour.cloud_coverage,
+            precipitation=hour.precipitation_amount,
+            humidity=hour.relative_humidity,
+            normalized_score=normalize_score(raw_score, self.activity_profile),
             rating=get_rating_info(raw_score, self.activity_profile),
+            coverage_hours=hour.coverage_hours,
+            in_best_window=_is_inside_window(hour, window),
         )
+
+
+def format_window(start: datetime, end: datetime) -> str:
+    """Format a recommended window as a start and end time."""
+    return f"{start:%H:%M} - {end:%H:%M}"
+
+
+def _is_inside_window(hour, window: Optional[tuple[datetime, datetime]]) -> bool:
+    """Return True when an entry falls inside the recommended window."""
+    if window is None:
+        return False
+    start, end = window
+    return start <= hour.time < end
 
 
 def _format_best_window_details(block: dict) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,9 @@
-import tkinter as tk
 from datetime import date, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.core.models import HourlyWeather
-from src.gui.app import WeatherHelperApp
 
 
 @pytest.fixture
@@ -61,6 +59,7 @@ def sample_forecast_data():
 @pytest.fixture(scope="session")
 def tk_root():
     """Fixture to create a single Tkinter root for the entire test session."""
+    tk = pytest.importorskip("tkinter")
     root = tk.Tk()
     root.withdraw()
     yield root
@@ -106,6 +105,7 @@ def create_hour():
 @pytest.fixture
 def mock_app_dependencies():
     """Patch Tkinter dependencies in app module."""
+    pytest.importorskip("tkinter")
     with patch('src.gui.app.tk') as mock_tk, \
          patch('src.gui.app.ttk') as mock_ttk, \
          patch('src.gui.app.messagebox') as mock_msgbox, \
@@ -130,6 +130,8 @@ def mock_app_dependencies():
 @pytest.fixture
 def mock_app(mock_app_dependencies):
     """Create a mocked WeatherHelperApp with dependencies already mocked."""
+    from src.gui.app import WeatherHelperApp
+
     app = WeatherHelperApp()
 
     # Mock UI components

--- a/tests/test_daily_summary.py
+++ b/tests/test_daily_summary.py
@@ -1,7 +1,11 @@
 from datetime import date, datetime, timedelta
 
-from src.core.locations import ASTURIAS_LOCATIONS
-from src.mobile.daily_summary import build_daily_summary, format_daily_summary
+from src.core.locations import ASTURIAS_LOCATIONS, WORLDWIDE_LOCATIONS
+from src.mobile.daily_summary import (
+    build_daily_summary,
+    format_daily_summary,
+    resolve_priority_keys,
+)
 
 
 def _ranked_result(location_key, location_name, raw_score, start_hour):
@@ -97,3 +101,48 @@ def test_daily_summary_text_uses_aligned_columns_without_em_dash():
         rows[0].score_text
     ) + len(rows[0].score_text)
     assert "Daily outdoor windows for Thu, 06 Aug" in text
+
+
+def test_summary_can_be_limited_to_the_selected_activity(monkeypatch):
+    def fake_rank(forecasts, forecast_date, top_n, activity_profile):
+        return [_ranked_result("gijon", "Gijon", 18, 12)]
+
+    monkeypatch.setattr(
+        "src.mobile.daily_summary.get_top_locations_for_date", fake_rank
+    )
+
+    rows = build_daily_summary(
+        {"gijon": {}},
+        date(2026, 8, 6),
+        ASTURIAS_LOCATIONS,
+        activity_profiles=("beach_day",),
+    )
+
+    assert {row.activity_profile for row in rows} == {"beach_day"}
+
+
+def test_regions_without_the_pinned_cities_pin_nothing():
+    assert resolve_priority_keys(WORLDWIDE_LOCATIONS) == []
+    assert resolve_priority_keys(ASTURIAS_LOCATIONS) == ["oviedo", "gijon"]
+
+
+def test_a_region_without_pinned_cities_still_lists_alternatives(monkeypatch):
+    def fake_rank(forecasts, forecast_date, top_n, activity_profile):
+        return [
+            _ranked_result("tokyo", "Tokyo", 20, 12),
+            _ranked_result("paris", "Paris", 15, 13),
+        ]
+
+    monkeypatch.setattr(
+        "src.mobile.daily_summary.get_top_locations_for_date", fake_rank
+    )
+
+    rows = build_daily_summary(
+        {"tokyo": {}, "paris": {}},
+        date(2026, 8, 6),
+        WORLDWIDE_LOCATIONS,
+        activity_profiles=("hiking",),
+    )
+
+    assert [row.location_name for row in rows] == ["Tokyo", "Paris"]
+    assert not any(row.is_priority for row in rows)

--- a/tests/test_daily_summary.py
+++ b/tests/test_daily_summary.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from src.core.locations import ASTURIAS_LOCATIONS
 from src.mobile.daily_summary import build_daily_summary, format_daily_summary
@@ -13,6 +13,7 @@ def _ranked_result(location_key, location_name, raw_score, start_hour):
         "optimal_block": {
             "start": start,
             "end": start,
+            "end_time": start + timedelta(hours=1),
         },
     }
 

--- a/tests/test_forecast_resolution.py
+++ b/tests/test_forecast_resolution.py
@@ -158,3 +158,31 @@ def test_daylight_bounds_leave_an_ordinary_hour_alone():
 
     assert start == midday.time
     assert end == midday.end_time
+
+
+def test_rain_hours_never_exceed_the_daylight_the_day_has():
+    """Six-hour entries hang off both ends of the day; rain hours must not."""
+    from src.core.models import DailyReport
+
+    hours = [
+        _hour(8, coverage_hours=6, precipitation_amount=6.0),
+        _hour(14, coverage_hours=6, precipitation_amount=6.0),
+        _hour(20, coverage_hours=6, precipitation_amount=6.0),
+    ]
+
+    report = DailyReport(datetime(2026, 8, 10), hours, "Test")
+    daylight_length = DAYLIGHT_END_HOUR + 1 - DAYLIGHT_START_HOUR
+
+    assert report.likely_rain_hours <= daylight_length
+    assert report.weather_description == f"Rain ({daylight_length}h)"
+
+
+def test_a_block_hanging_off_the_end_of_the_day_earns_no_extra_credit():
+    """A 20:00 six-hour entry offers one usable hour, not six."""
+    late = _hour(20, coverage_hours=6, precipitation_amount=0.0)
+
+    block = find_optimal_weather_block([late], activity_profile=ACTIVITY_BEACH_DAY)
+
+    assert block is not None
+    assert block["positive_hour_count"] <= 1
+    assert block["duration_hours"] == 1

--- a/tests/test_forecast_resolution.py
+++ b/tests/test_forecast_resolution.py
@@ -4,8 +4,10 @@ from datetime import datetime, timedelta
 
 import pytz
 
+from src.core.config import DAYLIGHT_END_HOUR, DAYLIGHT_START_HOUR
 from src.core.evaluation import (
     _are_adjacent_forecast_hours,
+    daylight_bounds,
     find_optimal_weather_block,
     process_forecast,
 )
@@ -123,3 +125,36 @@ def test_a_block_reports_the_hours_it_actually_covers():
     assert block["duration"] == 1
     assert block["duration_hours"] == 6
     assert block["end_time"] == block["end"] + timedelta(hours=6)
+
+
+def test_a_window_is_never_reported_as_starting_before_dawn():
+    """A six-hour entry can start at 04:00; a recommendation cannot."""
+    pre_dawn = _hour(4, coverage_hours=6, precipitation_amount=0.0)
+
+    block = find_optimal_weather_block(
+        [pre_dawn], activity_profile=ACTIVITY_BEACH_DAY
+    )
+
+    assert block is not None
+    assert block["start"].hour == DAYLIGHT_START_HOUR
+    # Only the daylight part of the entry counts as time you can use.
+    assert block["duration_hours"] == 2
+
+
+def test_a_window_is_never_reported_as_running_past_dusk():
+    late = _hour(18, coverage_hours=6, precipitation_amount=0.0)
+
+    block = find_optimal_weather_block([late], activity_profile=ACTIVITY_BEACH_DAY)
+
+    assert block is not None
+    assert block["end_time"].hour == DAYLIGHT_END_HOUR + 1
+    assert block["duration_hours"] == 3
+
+
+def test_daylight_bounds_leave_an_ordinary_hour_alone():
+    midday = _hour(12)
+
+    start, end = daylight_bounds(midday)
+
+    assert start == midday.time
+    assert end == midday.end_time

--- a/tests/test_forecast_resolution.py
+++ b/tests/test_forecast_resolution.py
@@ -1,0 +1,125 @@
+"""Tests for six-hourly forecast data being reported and scored honestly."""
+
+from datetime import datetime, timedelta
+
+import pytz
+
+from src.core.evaluation import (
+    _are_adjacent_forecast_hours,
+    find_optimal_weather_block,
+    process_forecast,
+)
+from src.core.models import HourlyWeather
+from src.core.scoring import ACTIVITY_BEACH_DAY, get_activity_score
+
+MADRID = pytz.timezone("Europe/Madrid")
+
+
+def _entry(timestamp: str, period_key: str, precipitation: float) -> dict:
+    return {
+        "time": timestamp,
+        "data": {
+            "instant": {
+                "details": {
+                    "air_temperature": 22,
+                    "wind_speed": 2,
+                    "cloud_area_fraction": 15,
+                    "relative_humidity": 55,
+                }
+            },
+            period_key: {
+                "summary": {"symbol_code": "rain"},
+                "details": {
+                    "precipitation_amount": precipitation,
+                    "probability_of_precipitation": 20,
+                },
+            },
+        },
+    }
+
+
+def _hour(hour: int, coverage_hours: int = 1, **kwargs) -> HourlyWeather:
+    base = datetime.now(MADRID).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    ) + timedelta(days=1)
+    return HourlyWeather(
+        time=base + timedelta(hours=hour),
+        coverage_hours=coverage_hours,
+        temp=22,
+        wind=2,
+        cloud_coverage=15,
+        relative_humidity=55,
+        **kwargs,
+    )
+
+
+def _tomorrow_utc(hour: int) -> str:
+    instant = datetime.now(pytz.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    ) + timedelta(days=1, hours=hour)
+    return instant.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_hourly_entries_are_marked_as_one_hour():
+    payload = {
+        "properties": {"timeseries": [_entry(_tomorrow_utc(10), "next_1_hours", 0.2)]}
+    }
+
+    processed = process_forecast(payload, "Test", "Europe/Madrid")
+    hour = next(iter(processed["daily_forecasts"].values()))[0]
+
+    assert hour.coverage_hours == 1
+    assert hour.is_hourly
+    assert hour.precipitation_rate == 0.2
+
+
+def test_six_hourly_entries_record_their_span_and_rate():
+    payload = {
+        "properties": {"timeseries": [_entry(_tomorrow_utc(10), "next_6_hours", 3.0)]}
+    }
+
+    processed = process_forecast(payload, "Test", "Europe/Madrid")
+    hour = next(iter(processed["daily_forecasts"].values()))[0]
+
+    assert hour.coverage_hours == 6
+    assert not hour.is_hourly
+    # 3 mm spread over six hours is light drizzle, not heavy rain.
+    assert hour.precipitation_amount == 3.0
+    assert hour.precipitation_rate == 0.5
+    assert hour.end_time == hour.time + timedelta(hours=6)
+
+
+def test_a_six_hour_total_is_not_scored_as_one_hour_of_rain():
+    six_hourly = _hour(10, coverage_hours=6, precipitation_amount=3.0)
+    hourly = _hour(10, coverage_hours=1, precipitation_amount=3.0)
+
+    assert get_activity_score(six_hourly, ACTIVITY_BEACH_DAY) > get_activity_score(
+        hourly, ACTIVITY_BEACH_DAY
+    )
+
+
+def test_entries_are_adjacent_when_one_ends_where_the_next_starts():
+    assert _are_adjacent_forecast_hours(_hour(10), _hour(11))
+    assert _are_adjacent_forecast_hours(
+        _hour(6, coverage_hours=6), _hour(12, coverage_hours=6)
+    )
+
+
+def test_entries_of_different_resolutions_are_never_adjacent():
+    assert not _are_adjacent_forecast_hours(_hour(10), _hour(11, coverage_hours=6))
+
+
+def test_entries_with_a_gap_between_them_are_not_adjacent():
+    assert not _are_adjacent_forecast_hours(_hour(10), _hour(13))
+
+
+def test_a_block_reports_the_hours_it_actually_covers():
+    block = find_optimal_weather_block(
+        [_hour(8, coverage_hours=6, precipitation_amount=0.0)],
+        activity_profile=ACTIVITY_BEACH_DAY,
+    )
+
+    assert block is not None
+    assert block["duration"] == 1
+    assert block["duration_hours"] == 6
+    assert block["end_time"] == block["end"] + timedelta(hours=6)

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -1,3 +1,5 @@
+import time
+
 from src.application.forecast_service import (
     DOWNLOAD_ERROR,
     UNEXPECTED_ERROR,
@@ -44,7 +46,10 @@ def test_load_locations_keeps_partial_success_and_reports_progress():
     assert batch.forecasts == {"good": {"name": "Good"}}
     assert batch.errors == {"bad": DOWNLOAD_ERROR}
     assert batch.loaded_count == 1
-    assert progress == [(1, 2, "good"), (2, 2, "bad")]
+    # Locations are fetched concurrently, so only the counts are guaranteed.
+    assert [current for current, _, _ in progress] == [1, 2]
+    assert {total for _, total, _ in progress} == {2}
+    assert {key for _, _, key in progress} == {"good", "bad"}
 
 
 def test_load_location_converts_dependency_exception_to_error():
@@ -58,3 +63,80 @@ def test_load_location_converts_dependency_exception_to_error():
     assert not result.succeeded
     assert result.error == UNEXPECTED_ERROR
     assert "network unavailable" not in result.error
+
+
+def test_locations_are_loaded_concurrently():
+    """A slow location must not hold up the rest of the region."""
+    locations = {
+        f"loc{index}": Location(f"loc{index}", f"Loc {index}", 1.0, 2.0)
+        for index in range(6)
+    }
+
+    def slow_fetch(location):
+        time.sleep(0.15)
+        return {}
+
+    service = ForecastService(
+        fetch_forecast=slow_fetch,
+        process=lambda payload, name, timezone_name=None: {"name": name},
+    )
+
+    started = time.monotonic()
+    batch = service.load_locations(locations)
+    elapsed = time.monotonic() - started
+
+    assert batch.loaded_count == 6
+    # Sequentially this would take at least 0.9s.
+    assert elapsed < 0.6
+
+
+def test_results_keep_the_requested_location_order():
+    locations = {
+        key: Location(key, key.title(), 1.0, 2.0)
+        for key in ("gijon", "oviedo", "llanes", "aviles")
+    }
+
+    def variable_fetch(location):
+        time.sleep(0.05 if location.key == "gijon" else 0.0)
+        return {}
+
+    service = ForecastService(
+        fetch_forecast=variable_fetch,
+        process=lambda payload, name, timezone_name=None: {"name": name},
+    )
+
+    batch = service.load_locations(locations)
+
+    assert list(batch.forecasts) == list(locations)
+
+
+def test_failed_locations_are_named_for_the_user():
+    locations = {
+        "gijon": Location("gijon", "Gijón", 1.0, 2.0),
+        "oviedo": Location("oviedo", "Oviedo", 1.0, 2.0),
+        "llanes": Location("llanes", "Llanes", 1.0, 2.0),
+    }
+    service = ForecastService(fetch_forecast=lambda location: None)
+
+    batch = service.load_locations(locations)
+
+    assert batch.failure_summary == "Gijón, Llanes, Oviedo"
+
+
+def test_a_long_list_of_failures_is_summarised():
+    locations = {
+        f"loc{index}": Location(f"loc{index}", f"Loc {index}", 1.0, 2.0)
+        for index in range(6)
+    }
+    service = ForecastService(fetch_forecast=lambda location: None)
+
+    batch = service.load_locations(locations)
+
+    assert batch.failure_summary.endswith("and 3 more")
+
+
+def test_loading_no_locations_is_not_an_error():
+    batch = ForecastService(fetch_forecast=lambda location: None).load_locations({})
+
+    assert batch.loaded_count == 0
+    assert batch.failure_summary == ""

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -12,7 +12,7 @@ def test_load_location_fetches_and_processes_forecast():
     processed = {"daily_forecasts": {}, "day_scores": {}}
     service = ForecastService(
         fetch_forecast=lambda requested: raw,
-        process=lambda payload, name: processed,
+        process=lambda payload, name, timezone_name=None: processed,
     )
 
     result = service.load_location(location)
@@ -31,7 +31,7 @@ def test_load_locations_keeps_partial_success_and_reports_progress():
     progress = []
     service = ForecastService(
         fetch_forecast=lambda location: {} if location.key == "good" else None,
-        process=lambda payload, name: {"name": name},
+        process=lambda payload, name, timezone_name=None: {"name": name},
     )
 
     batch = service.load_locations(

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,12 +1,13 @@
 """Tests for formatting utilities."""
 
-import tkinter as tk
 from datetime import date, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.gui.formatting import (
+tk = pytest.importorskip("tkinter")
+
+from src.gui.formatting import (  # noqa: E402
     ToolTip,
     add_tooltip,
     format_date,
@@ -17,7 +18,7 @@ from src.gui.formatting import (
     format_time,
     format_wind_speed,
 )
-from src.gui.themes import get_rating_color
+from src.gui.themes import get_rating_color  # noqa: E402
 
 
 def test_format_temperature():

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -1,10 +1,13 @@
 import pytest
 from unittest.mock import MagicMock
-from src.application.forecast_service import LocationForecastResult
-from src.gui.app import WeatherHelperApp
-from src.core.locations import LOCATION_GROUPS
 
 pytestmark = pytest.mark.windows_gui
+
+pytest.importorskip("tkinter")
+
+from src.application.forecast_service import LocationForecastResult  # noqa: E402
+from src.core.locations import LOCATION_GROUPS  # noqa: E402
+from src.gui.app import WeatherHelperApp  # noqa: E402
 
 
 def test_group_switching_logic(mock_app):

--- a/tests/test_mobile_entry_point.py
+++ b/tests/test_mobile_entry_point.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.mobile import app
+from src.mobile.theme import Palette
 
 
 def test_missing_flet_has_actionable_install_message(monkeypatch):
@@ -24,5 +25,16 @@ def test_missing_flet_has_actionable_install_message(monkeypatch):
     ],
 )
 def test_mobile_rating_colors_match_windows_palette(rating, expected):
-    assert app.rating_color(rating) == expected
-    assert app.rating_background(rating) != app.SURFACE_COLOR
+    light = Palette(dark=False)
+
+    assert light.rating(rating) == expected
+    assert light.rating_background(rating) != light.surface
+
+
+@pytest.mark.parametrize("rating", ["Excellent", "Very Good", "Good", "Fair", "Poor"])
+def test_every_rating_stays_distinguishable_in_dark_mode(rating):
+    dark = Palette(dark=True)
+
+    assert dark.rating(rating) != dark.text
+    assert dark.rating_background(rating) != dark.surface
+    assert dark.rating(rating) != Palette(dark=False).rating(rating)

--- a/tests/test_mobile_screen.py
+++ b/tests/test_mobile_screen.py
@@ -1,0 +1,365 @@
+"""Tests for the mobile screen, driven through a stand-in for Flet.
+
+Flet cannot be rendered in CI, so the screen is exercised against a recording
+double. That is enough to prove the parts that used to break silently: which
+values reach the user, what is built lazily, and how failures are surfaced.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.application.forecast_service import ForecastBatch
+from src.core.config import get_current_date
+from src.core.models import DailyReport, HourlyWeather
+from src.core.scoring import (
+    cloud_score,
+    humidity_score,
+    precip_amount_score,
+    temp_score,
+    wind_score,
+)
+from src.mobile.app import create_mobile_app
+from src.mobile.view_model import MobileWeatherViewModel
+
+flet = pytest.importorskip("flet")
+
+
+class StubService:
+    def __init__(self, batch, error=None):
+        self.batch = batch
+        self.error = error
+        self.calls = 0
+
+    def load_locations(self, locations, on_progress=None):
+        self.calls += 1
+        if self.error:
+            raise self.error
+        if on_progress:
+            for index, location in enumerate(locations.values(), 1):
+                on_progress(index, len(locations), location)
+        return self.batch
+
+
+class FakePage:
+    """A page that records what the screen puts on it."""
+
+    def __init__(self):
+        self.controls = []
+        self.appbar = None
+        self.title = ""
+        self.padding = None
+        self.bgcolor = None
+        self.theme_mode = None
+        self.platform_brightness = flet.Brightness.LIGHT
+        self.on_platform_brightness_change = None
+        self.on_app_lifecycle_state_change = None
+        self.updates = 0
+        self.tasks = []
+
+    def add(self, *controls):
+        self.controls.extend(controls)
+
+    def update(self):
+        self.updates += 1
+
+    def run_task(self, handler, *args, **kwargs):
+        self.tasks.append((handler, args, kwargs))
+
+
+def _hour(forecast_date, hour_of_day, temp=24, **overrides):
+    values = {
+        "temp": temp,
+        "wind": 2,
+        "cloud_coverage": 15,
+        "precipitation_amount": 0.0,
+        "precipitation_probability": 5,
+        "relative_humidity": 55,
+    }
+    values.update(overrides)
+    return HourlyWeather(
+        time=datetime.combine(forecast_date, datetime.min.time()).replace(
+            hour=hour_of_day
+        ),
+        temp_score=temp_score(values["temp"]),
+        wind_score=wind_score(values["wind"]),
+        cloud_score=cloud_score(values["cloud_coverage"]),
+        precip_amount_score=precip_amount_score(values["precipitation_amount"]),
+        humidity_score=humidity_score(values["relative_humidity"]),
+        **values,
+    )
+
+
+def _processed(name, forecast_date, hours):
+    return {
+        "daily_forecasts": {forecast_date: hours},
+        "day_scores": {
+            forecast_date: DailyReport(
+                datetime.combine(forecast_date, datetime.min.time()), hours, name
+            )
+        },
+        "timezone": "Europe/Madrid",
+    }
+
+
+def _batch(forecast_date, **extra):
+    forecasts = {
+        "gijon": _processed(
+            "Gijón", forecast_date, [_hour(forecast_date, h, 26) for h in range(10, 18)]
+        ),
+        "oviedo": _processed(
+            "Oviedo", forecast_date, [_hour(forecast_date, h, 15) for h in range(10, 18)]
+        ),
+    }
+    forecasts.update(extra)
+    return ForecastBatch(forecasts=forecasts)
+
+
+def _screen(batch=None, error=None, brightness=None):
+    """Build the screen and run its initial load synchronously."""
+    forecast_date = get_current_date() + timedelta(days=1)
+    model = MobileWeatherViewModel(
+        service=StubService(batch or _batch(forecast_date), error)
+    )
+    page = FakePage()
+    if brightness is not None:
+        page.platform_brightness = brightness
+    create_mobile_app(page, ft=flet, view_model=model)
+    return page, model
+
+
+def _run_pending_tasks(page):
+    import asyncio
+
+    while page.tasks:
+        handler, args, kwargs = page.tasks.pop(0)
+        result = handler(*args, **kwargs)
+        if asyncio.iscoroutine(result):
+            asyncio.run(result)
+
+
+def _all_text(control, found=None):
+    """Collect every string rendered anywhere in a control tree."""
+    found = [] if found is None else found
+    if isinstance(control, flet.Text) and control.value:
+        found.append(control.value)
+    if isinstance(control, flet.Markdown) and control.value:
+        found.append(control.value)
+    for attribute in ("controls", "actions"):
+        for child in getattr(control, attribute, None) or []:
+            _all_text(child, found)
+    for attribute in ("content", "title", "subtitle", "leading", "trailing"):
+        child = getattr(control, attribute, None)
+        if child is not None and not isinstance(child, str):
+            _all_text(child, found)
+    return found
+
+
+def _screen_text(page):
+    texts = []
+    for control in page.controls:
+        _all_text(control, texts)
+    if page.appbar is not None:
+        _all_text(page.appbar, texts)
+    return texts
+
+
+def test_the_screen_leads_with_the_best_place_and_window():
+    page, model = _screen()
+    _run_pending_tasks(page)
+
+    texts = _screen_text(page)
+    best = model.top_recommendation()
+
+    assert best is not None
+    assert best.location_name == "Gijón"
+    # The answer, the window and the score are all present without expanding.
+    assert "Gijón" in texts
+    assert best.best_window in texts
+    assert str(best.normalized_score) in texts
+
+
+def test_scores_are_always_shown_out_of_one_hundred():
+    page, _ = _screen()
+    _run_pending_tasks(page)
+
+    texts = _screen_text(page)
+
+    assert "/100" in texts
+    assert any(text == "Excellent" or text == "Very Good" for text in texts)
+
+
+def test_a_ratings_legend_is_always_visible():
+    page, _ = _screen()
+    _run_pending_tasks(page)
+
+    texts = _screen_text(page)
+
+    for rating in ("Excellent", "Very Good", "Good", "Fair", "Poor"):
+        assert rating in texts
+
+
+def test_collapsed_cards_do_not_build_their_hourly_rows():
+    page, model = _screen()
+    _run_pending_tasks(page)
+
+    texts = _screen_text(page)
+
+    # Nothing is expanded, so no hourly time labels are rendered yet.
+    assert "10:00" not in texts
+    assert "11:00" not in texts
+
+
+def test_expanding_a_card_builds_its_hours_and_marks_the_best_window():
+    page, model = _screen()
+    _run_pending_tasks(page)
+    screen = _find_screen(page)
+
+    screen.on_tile_toggle("gijon", True)
+
+    texts = _screen_text(page)
+    assert "10:00" in texts
+    assert "BEST" in texts
+
+
+def test_collapsing_a_card_drops_its_hourly_rows_again():
+    page, _ = _screen()
+    _run_pending_tasks(page)
+    screen = _find_screen(page)
+
+    screen.on_tile_toggle("gijon", True)
+    screen.on_tile_toggle("gijon", False)
+
+    assert "10:00" not in _screen_text(page)
+
+
+def test_missing_readings_render_as_a_dash_not_as_weather():
+    forecast_date = get_current_date() + timedelta(days=1)
+    hours = [
+        _hour(forecast_date, hour, 24, precipitation_amount=None, cloud_coverage=None)
+        for hour in range(10, 18)
+    ]
+    batch = ForecastBatch(
+        forecasts={"gijon": _processed("Gijón", forecast_date, hours)}
+    )
+    page, _ = _screen(batch)
+    _run_pending_tasks(page)
+    screen = _find_screen(page)
+
+    screen.on_tile_toggle("gijon", True)
+
+    texts = _screen_text(page)
+    assert "—" in texts
+    assert "0.0 mm" not in texts
+
+
+def test_a_failed_load_says_so_instead_of_showing_nothing():
+    page, _ = _screen(error=RuntimeError("no network"))
+    _run_pending_tasks(page)
+
+    texts = _screen_text(page)
+
+    assert any("Could not load forecasts" in text for text in texts)
+
+
+def test_unavailable_locations_are_named():
+    forecast_date = get_current_date() + timedelta(days=1)
+    batch = ForecastBatch(
+        forecasts={
+            "gijon": _processed(
+                "Gijón",
+                forecast_date,
+                [_hour(forecast_date, h) for h in range(10, 18)],
+            )
+        },
+        errors={"oviedo": "offline"},
+        failed_names={"oviedo": "Oviedo"},
+    )
+    page, _ = _screen(batch)
+    _run_pending_tasks(page)
+
+    texts = _screen_text(page)
+
+    assert any("Oviedo" in text and "unavailable" in text for text in texts)
+
+
+def test_the_screen_reports_when_the_data_was_loaded():
+    page, _ = _screen()
+    _run_pending_tasks(page)
+
+    assert any("Updated" in text for text in _screen_text(page))
+
+
+def test_days_are_labelled_relative_to_today():
+    page, _ = _screen()
+    _run_pending_tasks(page)
+    screen = _find_screen(page)
+
+    labels = [option.text for option in screen.date_dropdown.options]
+
+    assert "Tomorrow" in labels
+
+
+def test_the_dark_palette_is_used_on_a_dark_device():
+    page, _ = _screen(brightness=flet.Brightness.DARK)
+    _run_pending_tasks(page)
+
+    assert page.bgcolor == "#0f172a"
+
+
+def test_a_stale_selection_recovers_instead_of_failing_silently():
+    page, model = _screen()
+    _run_pending_tasks(page)
+    screen = _find_screen(page)
+
+    # A location that is not available any more must not raise out of a handler.
+    screen.on_tile_toggle("nowhere", True)
+
+    assert any("no longer available" in text for text in _screen_text(page))
+
+
+def test_a_slow_load_never_overwrites_a_newer_one():
+    """Switching region twice quickly must not let the first result win."""
+    import asyncio
+    import threading
+
+    forecast_date = get_current_date() + timedelta(days=1)
+    release_first = threading.Event()
+
+    class SlowThenFastService:
+        def __init__(self):
+            self.calls = 0
+
+        def load_locations(self, locations, on_progress=None):
+            self.calls += 1
+            if self.calls == 1:
+                release_first.wait(timeout=5)
+                return ForecastBatch(forecasts={}, errors={"all": "stale"})
+            return _batch(forecast_date)
+
+    model = MobileWeatherViewModel(service=SlowThenFastService())
+    page = FakePage()
+    create_mobile_app(page, ft=flet, view_model=model)
+    page.tasks.clear()  # Drive the loads explicitly instead.
+    screen = _find_screen(page)
+
+    async def overlapping_loads():
+        slow = asyncio.create_task(screen.refresh_forecast())
+        await asyncio.sleep(0)
+        fast = asyncio.create_task(screen.refresh_forecast())
+        await fast
+        finished_status = screen.status.value
+        release_first.set()
+        await slow
+        return finished_status
+
+    status_after_fast = asyncio.run(overlapping_loads())
+
+    assert "2 locations loaded" in status_after_fast
+    # The stale result landed later but must not have replaced the newer one.
+    assert screen.status.value == status_after_fast
+
+
+def _find_screen(page):
+    """Recover the screen object from the handlers it registered."""
+    return page.on_platform_brightness_change.__self__

--- a/tests/test_mobile_screen.py
+++ b/tests/test_mobile_screen.py
@@ -11,7 +11,7 @@ import pytest
 
 from src.application.forecast_service import ForecastBatch
 from src.core.config import get_current_date
-from src.core.models import DailyReport, HourlyWeather
+from src.core.models import DailyReport, HourlyWeather  # noqa: F401
 from src.core.scoring import (
     cloud_score,
     humidity_score,
@@ -363,3 +363,44 @@ def test_a_slow_load_never_overwrites_a_newer_one():
 def _find_screen(page):
     """Recover the screen object from the handlers it registered."""
     return page.on_platform_brightness_change.__self__
+
+
+def test_a_six_hour_row_shows_the_rate_it_was_scored_on():
+    """The number on screen must be the number the rating came from."""
+    forecast_date = get_current_date() + timedelta(days=1)
+    block = HourlyWeather(
+        time=datetime.combine(forecast_date, datetime.min.time()).replace(hour=10),
+        coverage_hours=6,
+        temp=24,
+        wind=2,
+        cloud_coverage=15,
+        precipitation_amount=3.0,
+        relative_humidity=55,
+    )
+    batch = ForecastBatch(
+        forecasts={"gijon": _processed("Gijón", forecast_date, [block])}
+    )
+    page, model = _screen(batch)
+    _run_pending_tasks(page)
+    screen = _find_screen(page)
+
+    screen.on_tile_toggle("gijon", True)
+
+    texts = _screen_text(page)
+    # 3 mm across six hours is 0.5 mm/h, which is what the score reflects.
+    assert "0.5 mm/h" in texts
+    assert "3.0 mm" not in texts
+    assert "6h block" in texts
+
+
+def test_progress_updates_do_not_survive_the_load_they_belong_to():
+    """A late progress callback must not overwrite the finished result."""
+    page, _ = _screen()
+    _run_pending_tasks(page)
+    screen = _find_screen(page)
+
+    final_status = screen.status.value
+    _run_pending_tasks(page)  # Drain any progress updates queued during the load.
+
+    assert screen.status.value == final_status
+    assert "loaded" in final_status

--- a/tests/test_mobile_view_model.py
+++ b/tests/test_mobile_view_model.py
@@ -14,8 +14,11 @@ class StubForecastService:
         self.batch = batch
         self.requested_locations = None
 
-    def load_locations(self, locations):
+    def load_locations(self, locations, on_progress=None):
         self.requested_locations = locations
+        if on_progress:
+            for index, location in enumerate(locations.values(), 1):
+                on_progress(index, len(locations), location)
         return self.batch
 
 
@@ -68,11 +71,13 @@ def test_load_exposes_dates_rankings_and_hourly_details():
     assert "Temp: 24.0°C" in ranked[0].best_window_details
     assert "Rain Risk" not in ranked[0].best_window_details
     assert hourly[0].time == "12:00"
-    assert hourly[0].temperature == "24.0°C"
-    assert hourly[0].wind == "2.0 m/s"
-    assert hourly[0].clouds == "20%"
-    assert hourly[0].precipitation == "0.0 mm"
-    assert hourly[0].humidity == "60%"
+    assert hourly[0].temperature == 24
+    assert hourly[0].wind == 2
+    assert hourly[0].clouds == 20
+    assert hourly[0].precipitation == 0
+    assert hourly[0].humidity == 60
+    assert hourly[0].in_best_window
+    assert hourly[0].is_hourly
     assert hourly[0].normalized_score == 90
     assert hourly[0].rating == "Excellent"
     assert service.requested_locations == model.locations
@@ -121,7 +126,7 @@ def test_loaded_location_without_qualifying_block_is_selectable():
     assert selected is not None
     assert not selected.is_ranked
     assert selected.normalized_score is None
-    assert "No qualifying recommended window" in selected.best_window_details
+    assert "good enough to recommend" in selected.best_window_details
     assert model.hourly_forecast("gijon")[0].time == "12:00"
 
 

--- a/tests/test_recommendation_hours.py
+++ b/tests/test_recommendation_hours.py
@@ -1,0 +1,165 @@
+"""The ranking, the window and the hourly breakdown share one set of hours."""
+
+from datetime import datetime, timedelta
+
+import pytz
+
+from src.core.config import DAYLIGHT_END_HOUR, DAYLIGHT_START_HOUR, get_current_date
+from src.core.evaluation import get_recommendation_hours, get_top_locations_for_date
+from src.core.models import DailyReport, HourlyWeather
+from src.core.scoring import (
+    ACTIVITY_HIKING,
+    cloud_score,
+    humidity_score,
+    precip_amount_score,
+    temp_score,
+    wind_score,
+)
+
+MADRID = pytz.timezone("Europe/Madrid")
+
+
+def _hour(forecast_date, hour_of_day, temp=22):
+    """Build an entry whose scores really follow from its weather."""
+    return HourlyWeather(
+        time=MADRID.localize(
+            datetime.combine(forecast_date, datetime.min.time())
+        ).replace(hour=hour_of_day),
+        temp=temp,
+        wind=2,
+        cloud_coverage=20,
+        precipitation_amount=0.0,
+        precipitation_probability=5,
+        relative_humidity=55,
+        temp_score=temp_score(temp),
+        cloud_score=cloud_score(20),
+        precip_amount_score=precip_amount_score(0.0),
+        humidity_score=humidity_score(55),
+        wind_score=wind_score(2),
+    )
+
+
+def _processed(forecast_date, hours):
+    return {
+        "daily_forecasts": {forecast_date: hours},
+        "day_scores": {
+            forecast_date: DailyReport(
+                datetime.combine(forecast_date, datetime.min.time()),
+                hours,
+                "Test",
+            )
+        },
+        "timezone": "Europe/Madrid",
+    }
+
+
+def test_night_hours_are_never_part_of_a_recommendation():
+    forecast_date = get_current_date() + timedelta(days=1)
+    all_day = [_hour(forecast_date, hour) for hour in range(24)]
+
+    considered = get_recommendation_hours(_processed(forecast_date, all_day), forecast_date)
+
+    assert considered
+    for hour in considered:
+        assert DAYLIGHT_START_HOUR <= hour.time.hour <= DAYLIGHT_END_HOUR
+
+
+def test_hours_that_have_already_passed_today_are_excluded():
+    today = get_current_date()
+    all_day = [_hour(today, hour) for hour in range(24)]
+    midday = MADRID.localize(
+        datetime.combine(today, datetime.min.time())
+    ).replace(hour=13, minute=5)
+
+    considered = get_recommendation_hours(_processed(today, all_day), today, midday)
+
+    # 13:00 still has 55 minutes left, so it counts; everything earlier is gone.
+    assert [hour.time.hour for hour in considered] == list(
+        range(13, DAYLIGHT_END_HOUR + 1)
+    )
+
+
+def test_an_hour_that_is_nearly_over_is_not_recommended():
+    today = get_current_date()
+    all_day = [_hour(today, hour) for hour in range(24)]
+    nearly_two = MADRID.localize(
+        datetime.combine(today, datetime.min.time())
+    ).replace(hour=13, minute=45)
+
+    considered = get_recommendation_hours(_processed(today, all_day), today, nearly_two)
+
+    assert considered[0].time.hour == 14
+
+
+def test_a_future_day_keeps_its_whole_daylight_window():
+    forecast_date = get_current_date() + timedelta(days=2)
+    all_day = [_hour(forecast_date, hour) for hour in range(24)]
+
+    considered = get_recommendation_hours(_processed(forecast_date, all_day), forecast_date)
+
+    assert [hour.time.hour for hour in considered] == list(
+        range(DAYLIGHT_START_HOUR, DAYLIGHT_END_HOUR + 1)
+    )
+
+
+def test_todays_rank_ignores_a_good_morning_that_has_already_passed(monkeypatch):
+    """The rank must describe the time you can still act on, not the whole day."""
+    today = get_current_date()
+    afternoon = MADRID.localize(
+        datetime.combine(today, datetime.min.time())
+    ).replace(hour=15)
+    monkeypatch.setattr(
+        "src.core.evaluation._location_now", lambda processed: afternoon
+    )
+
+    # A glorious morning followed by a cold, grim rest of the day.
+    hours = [_hour(today, hour, 22) for hour in range(DAYLIGHT_START_HOUR, 15)]
+    hours += [_hour(today, hour, 3) for hour in range(15, DAYLIGHT_END_HOUR + 1)]
+    remaining_only = [hour for hour in hours if hour.time.hour >= 15]
+
+    ranked_full_day = get_top_locations_for_date(
+        {"a": _processed(today, hours)}, today, activity_profile=ACTIVITY_HIKING
+    )
+    ranked_remaining = get_top_locations_for_date(
+        {"a": _processed(today, remaining_only)},
+        today,
+        activity_profile=ACTIVITY_HIKING,
+    )
+
+    assert ranked_full_day and ranked_remaining
+    assert ranked_full_day[0]["score"] == ranked_remaining[0]["score"]
+
+
+def test_night_hours_never_change_a_rank():
+    forecast_date = get_current_date() + timedelta(days=1)
+    daylight = list(range(DAYLIGHT_START_HOUR, DAYLIGHT_END_HOUR + 1))
+    warm_day = _processed(forecast_date, [_hour(forecast_date, h, 22) for h in daylight])
+    warm_day_with_cold_night = _processed(
+        forecast_date,
+        [_hour(forecast_date, h, 22) for h in daylight]
+        + [_hour(forecast_date, h, -20) for h in (0, 1, 2, 3, 22, 23)],
+    )
+
+    ranked_clean = get_top_locations_for_date(
+        {"a": warm_day}, forecast_date, activity_profile=ACTIVITY_HIKING
+    )
+    ranked_with_night = get_top_locations_for_date(
+        {"a": warm_day_with_cold_night}, forecast_date, activity_profile=ACTIVITY_HIKING
+    )
+
+    assert ranked_clean[0]["score"] == ranked_with_night[0]["score"]
+
+
+def test_the_breakdown_shows_exactly_the_hours_the_ranking_used():
+    forecast_date = get_current_date() + timedelta(days=1)
+    all_day = [_hour(forecast_date, hour) for hour in range(24)]
+    processed = _processed(forecast_date, all_day)
+
+    ranked = get_top_locations_for_date(
+        {"a": processed}, forecast_date, activity_profile=ACTIVITY_HIKING
+    )
+    considered = get_recommendation_hours(processed, forecast_date)
+    window = ranked[0]["optimal_block"]
+
+    assert window["start"] >= considered[0].time
+    assert window["end_time"] <= considered[-1].end_time

--- a/tests/test_recommendation_hours.py
+++ b/tests/test_recommendation_hours.py
@@ -163,3 +163,51 @@ def test_the_breakdown_shows_exactly_the_hours_the_ranking_used():
 
     assert window["start"] >= considered[0].time
     assert window["end_time"] <= considered[-1].end_time
+
+
+def test_an_entry_missing_core_readings_is_never_recommended():
+    """A gap in the data must not be scored as if it were mild weather."""
+    forecast_date = get_current_date() + timedelta(days=1)
+    complete = [_hour(forecast_date, hour) for hour in (10, 11, 12)]
+    incomplete = [
+        HourlyWeather(
+            time=hour.time,
+            temp=None,
+            wind=None,
+            cloud_coverage=None,
+            precipitation_amount=None,
+            relative_humidity=None,
+        )
+        for hour in complete
+    ]
+
+    ranked_complete = get_top_locations_for_date(
+        {"a": _processed(forecast_date, complete)},
+        forecast_date,
+        activity_profile=ACTIVITY_HIKING,
+    )
+    ranked_incomplete = get_top_locations_for_date(
+        {"a": _processed(forecast_date, incomplete)},
+        forecast_date,
+        activity_profile=ACTIVITY_HIKING,
+    )
+
+    assert ranked_complete
+    assert ranked_incomplete == []
+
+
+def test_the_window_score_describes_the_window_not_the_day():
+    """A brilliant hour in a poor day must not be reported as a poor window."""
+    forecast_date = get_current_date() + timedelta(days=1)
+    hours = [_hour(forecast_date, 10, 22), _hour(forecast_date, 11, 22)]
+    hours += [_hour(forecast_date, hour, 2) for hour in range(12, 21)]
+
+    ranked = get_top_locations_for_date(
+        {"a": _processed(forecast_date, hours)},
+        forecast_date,
+        activity_profile=ACTIVITY_HIKING,
+    )
+
+    result = ranked[0]
+    assert result["window_score"] > result["score"]
+    assert result["optimal_block"]["start"].hour == 10

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -5,6 +5,9 @@ import pytest
 from src.core.scoring import (
     ACTIVITY_BEACH_DAY,
     ACTIVITY_HIKING,
+    MAX_BEACH_SCORE,
+    MAX_HIKING_SCORE,
+    NORMALIZATION_CONFIG_BY_PROFILE,
     beach_day_score,
     beach_precip_probability_score,
     get_activity_profile_key,
@@ -176,3 +179,22 @@ def test_beach_rating_and_normalization_use_beach_thresholds():
     assert get_rating_info(22, ACTIVITY_BEACH_DAY) == "Excellent"
     assert normalize_score(22, ACTIVITY_BEACH_DAY) == 90
     assert normalize_score(26, ACTIVITY_BEACH_DAY) == 100
+
+
+def test_perfect_conditions_reach_one_hundred_for_every_profile():
+    """A 100 must mean the same thing whichever activity is selected."""
+    assert normalize_score(MAX_HIKING_SCORE, ACTIVITY_HIKING) == 100
+    assert normalize_score(MAX_BEACH_SCORE, ACTIVITY_BEACH_DAY) == 100
+
+
+def test_the_normalisation_ceiling_matches_what_the_ranges_can_award():
+    for profile, maximum in (
+        (ACTIVITY_HIKING, MAX_HIKING_SCORE),
+        (ACTIVITY_BEACH_DAY, MAX_BEACH_SCORE),
+    ):
+        assert NORMALIZATION_CONFIG_BY_PROFILE[profile][4] == maximum
+
+
+def test_the_top_rating_is_reachable_for_every_profile():
+    assert get_rating_info(MAX_HIKING_SCORE, ACTIVITY_HIKING) == "Excellent"
+    assert get_rating_info(MAX_BEACH_SCORE, ACTIVITY_BEACH_DAY) == "Excellent"

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -2,14 +2,15 @@
 Tests for GUI themes and styling functionality.
 """
 
-import tkinter as tk
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.gui.themes import BORDER, COLORS, FONTS, PADDING, apply_theme, get_rating_color
-
 pytestmark = pytest.mark.windows_gui
+
+tk = pytest.importorskip("tkinter")
+
+from src.gui.themes import BORDER, COLORS, FONTS, PADDING, apply_theme, get_rating_color  # noqa: E402
 
 
 class TestColorsAndConstants:

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -1,0 +1,109 @@
+"""Tests that forecasts are interpreted in each location's own time zone."""
+
+from datetime import datetime, time, timedelta
+
+import pytest
+import pytz
+
+from src.core.config import get_current_date, get_timezone
+from src.core.evaluation import process_forecast
+from src.core.locations import LOCATION_GROUPS, Location
+
+
+def _timeseries_entry(timestamp: str) -> dict:
+    return {
+        "time": timestamp,
+        "data": {
+            "instant": {
+                "details": {
+                    "air_temperature": 20,
+                    "wind_speed": 2,
+                    "cloud_area_fraction": 20,
+                    "relative_humidity": 55,
+                }
+            },
+            "next_1_hours": {
+                "summary": {"symbol_code": "clearsky_day"},
+                "details": {
+                    "precipitation_amount": 0,
+                    "probability_of_precipitation": 0,
+                },
+            },
+        },
+    }
+
+
+def test_every_known_location_declares_a_valid_timezone():
+    for group in LOCATION_GROUPS.values():
+        for location in group.values():
+            assert pytz.timezone(location.timezone) is not None
+
+
+def test_unknown_timezone_falls_back_to_the_default():
+    assert get_timezone("Not/AZone").zone == get_timezone().zone
+
+
+def _utc_timestamp_within_forecast_window(hour: int) -> datetime:
+    """Return a UTC instant tomorrow, safely inside the processing window."""
+    tomorrow = datetime.now(pytz.utc).date() + timedelta(days=1)
+    return datetime.combine(tomorrow, time(hour=hour), tzinfo=pytz.utc)
+
+
+def test_forecast_times_use_the_location_timezone():
+    instant = _utc_timestamp_within_forecast_window(12)
+    payload = {
+        "properties": {
+            "timeseries": [_timeseries_entry(instant.strftime("%Y-%m-%dT%H:%M:%SZ"))]
+        }
+    }
+
+    madrid = process_forecast(payload, "Madrid", "Europe/Madrid")
+    tokyo = process_forecast(payload, "Tokyo", "Asia/Tokyo")
+
+    madrid_hour = next(iter(madrid["daily_forecasts"].values()))[0]
+    tokyo_hour = next(iter(tokyo["daily_forecasts"].values()))[0]
+
+    assert madrid_hour.time.hour == instant.astimezone(
+        pytz.timezone("Europe/Madrid")
+    ).hour
+    assert tokyo_hour.time.hour == instant.astimezone(pytz.timezone("Asia/Tokyo")).hour
+    assert madrid_hour.time.hour != tokyo_hour.time.hour
+
+
+def test_a_late_utc_hour_lands_on_the_next_local_day_in_the_east():
+    instant = _utc_timestamp_within_forecast_window(20)
+    payload = {
+        "properties": {
+            "timeseries": [_timeseries_entry(instant.strftime("%Y-%m-%dT%H:%M:%SZ"))]
+        }
+    }
+
+    tokyo = process_forecast(payload, "Tokyo", "Asia/Tokyo")
+    madrid = process_forecast(payload, "Madrid", "Europe/Madrid")
+
+    tokyo_date = next(iter(tokyo["daily_forecasts"]))
+    madrid_date = next(iter(madrid["daily_forecasts"]))
+
+    assert tokyo_date == instant.date() + timedelta(days=1)
+    assert madrid_date == instant.date()
+
+
+def test_processed_forecast_records_its_timezone():
+    payload = {"properties": {"timeseries": []}}
+
+    processed = process_forecast(payload, "London", "Europe/London")
+
+    assert processed["timezone"] == "Europe/London"
+
+
+@pytest.mark.parametrize("timezone_name", ["Pacific/Kiritimati", "Pacific/Midway"])
+def test_current_date_follows_the_requested_timezone(timezone_name):
+    expected = datetime.now(pytz.timezone(timezone_name)).date()
+
+    assert get_current_date(timezone_name) == expected
+
+
+def test_location_defaults_to_the_application_timezone():
+    location = Location("x", "X", 0.0, 0.0)
+
+    assert location.timezone == "Europe/Madrid"


### PR DESCRIPTION
Reworks the Android/Flet side of Weather Helper so the numbers it shows can be trusted, and so the answer it exists to give is visible without tapping anything.

## Correctness fixes

**Every forecast was interpreted in one hardcoded timezone.** `Europe/Madrid` was applied to all locations, so Tokyo's "14:00" row was really 22:00 there, and the 08:00–20:00 daylight window that drives the whole scoring engine was applied in Madrid hours — New York's afternoon fell outside it entirely. Locations now carry an IANA timezone, threaded through parsing, day grouping, and the per-location "now" used to drop hours that have passed.

**Days 3–7 were systematically wrong.** Beyond ~48h MET Norway publishes six-hourly entries, which were treated as single hours. A 3 mm six-hour drizzle was scored as 3 mm in one hour — a downpour. Windows displayed as `12:00 - 13:00` while covering six hours, and the adjacency check silently refused to join later-day entries into blocks at all. Entries now carry their real coverage span, driving adjacency, window end times, daylight overlap, duration bonuses and rain counting. Precipitation is scored as mm/h while the reported total is kept for display.

**The rank, the window and the hourly list each used a different set of hours.** The rank scored the whole daylight day, the window used only hours that hadn't passed, and the expanded card listed every entry stored for the date — including 03:00 and hours already gone. At 6pm a location could rank first on a morning that was over. `get_recommendation_hours` is now the single definition of which entries count, and all three read from it.

**Two scoring defects.** Perfect hiking weather could only ever reach 96/100 while perfect beach weather reached 100, because the normalisation ceiling was a hardcoded number that no longer matched what the ranges award — both are now derived from the ranges. And a missing reading scored as zero, indistinguishable from a mediocre real one; entries missing a core reading are now displayed but can no longer form a recommendation.

**Windows are clamped to daylight**, so a six-hour block starting at 04:00 is reported as the 08:00 part a person can actually use — and rain hours, duration bonuses and window lengths all read that same clipped figure. A day could previously report 18 hours of rain in a 13-hour day.

## Interface

The screen opens with the single best place and window for the selected activity and day, at a size that reads at arm's length, followed by the pinned locations, the ranked alternatives and a legend for the 0–100 scale.

Two scores are carried and **each states what it measures**: the window score leads the recommendation, the day score labels the ranking (the list is ordered by how settled the whole day looks), and the hourly rows inside a card add up to the window score. Previously a single unlabelled number was printed beside a specific time window while measuring the whole day.

Other fixes:

- The temperature icon was always orange — it parsed `"21.4°C"` expecting a space, so every reading hit the fallback. Readings are now driven from typed values, not formatted strings.
- A missing rainfall reading rendered as the heavy-rain icon. Missing data now shows a dash with a screen-reader label, which is what the README already claimed.
- The daily summary ignored the Activity filter and hardcoded a subtitle promising Oviedo and Gijón first — in Spain and Worldwide, where neither exists, it rendered an "Alternatives" heading with nothing above it.
- Locations were fetched one at a time behind a 10s timeout each; Worldwide could sit on an indeterminate bar for minutes. Requests now overlap, progress is reported per location, and failures are named rather than counted.
- Card bodies are built only when opened; one redraw no longer ranks the whole region several times.
- Event handlers recover visibly instead of failing silently, a superseded load can no longer overwrite a newer one, scroll-to-card uses a `ScrollKey` on the scrolling list, days read as Today/Tomorrow, the load time is shown, stale data refreshes on resume, and the palette follows the device into dark mode.

## Testing

`conftest.py` imported `tkinter` at module scope, so the entire suite — including the pure-logic mobile tests — failed to collect on any machine without Tk. That's fixed; Tk tests skip instead.

184 passing, 8 skipped. New coverage for timezones, six-hourly resolution, the shared hour set, and the mobile screen itself (driven through a recording stand-in for Flet, since Flet can't render in CI). The regression tests were checked against the old behaviour to confirm they actually fail without the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gi5m7kdGVsXsrkU8LiuKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013gi5m7kdGVsXsrkU8LiuKJ)_