### PR TITLE
Fix the Windows GUI test fixture for the block end_time key

### DIFF
--- a/tests/test_data_rendering.py
+++ b/tests/test_data_rendering.py
@@ -17,6 +17,9 @@ def test_populate_location_entry(mock_app):
         "optimal_block": {
             "start": datetime(2023, 1, 1, 10, 0),
             "end": datetime(2023, 1, 1, 14, 0),
+            # Blocks carry the instant they stop covering, which is how a
+            # six-hourly entry reports a window longer than one hour.
+            "end_time": datetime(2023, 1, 1, 15, 0),
             "temp": 22.5,
             "wind": 5.0,
             "precip": 0.0


### PR DESCRIPTION
Fixes `main`, which #38 left red.

## What broke

Blocks now carry `end_time` — the instant they stop covering — so a six-hourly entry can report a window longer than one hour. The Tkinter side panel reads that key, but one hand-built fixture in `tests/test_data_rendering.py` still supplied the old `start`/`end` pair:

```
src/gui/app.py:1034: KeyError: 'end_time'
FAILED tests/test_data_rendering.py::test_populate_location_entry
1 failed, 211 passed, 1 skipped
```

The fixture now matches what the evaluator actually produces. No production code changes.

## Why it wasn't caught

The test is marked `windows_gui`, so it is deselected on the Ubuntu job and skipped anywhere Tkinter is absent — including the review environment. I checked `src/` for uses of the old key but not the test fixtures.

Verified this time by installing Tk locally and running the complete suite the Windows job runs: **228 passed**, with the GUI tests actually executing rather than skipping. Reverting just this fixture reproduces the exact CI failure.

## Worth knowing

This workflow only triggers on `push` to `main`, so pull requests get no CI at all — a merge is the first time anything is checked. Adding a `pull_request` trigger would fix that, but the `version`, build and publish jobs carry no branch guard, so as written they would cut a release from every PR. That needs an `if: github.ref == 'refs/heads/main'` guard on those three jobs first. I have not changed the workflow here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gi5m7kdGVsXsrkU8LiuKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013gi5m7kdGVsXsrkU8LiuKJ)_